### PR TITLE
Add key to workers in worker container

### DIFF
--- a/site/source/tutorials/003_creating_widgets/demo/finished/biz-e-corp/src/widgets/WorkerContainer.ts
+++ b/site/source/tutorials/003_creating_widgets/demo/finished/biz-e-corp/src/widgets/WorkerContainer.ts
@@ -12,14 +12,17 @@ export default class WorkerContainer extends WorkerContainerBase<ThemeableProper
 	protected render(): DNode {
 		const workers: DNode[] = [
 			w(Worker, {
+				key: '1',
 				firstName: 'Tim',
 				lastName: 'Jones'
 			}),
 			w(Worker, {
+				key: '2',
 				firstName: 'Alicia',
 				lastName: 'Fitzgerald'
 			}),
 			w(Worker, {
+				key: '3',
 				firstName: 'Hans',
 				lastName: 'Mueller'
 			})

--- a/site/source/tutorials/003_creating_widgets/index.md
+++ b/site/source/tutorials/003_creating_widgets/index.md
@@ -330,14 +330,17 @@ Now we can update the `render` method to include some workers. Add the following
 ```ts
 const workers: DNode[] = [
 	w(Worker, {
+		key: 1,
 		firstName: 'Tim',
 		lastName: 'Jones'
 	}),
 	w(Worker, {
+		key: 2,
 		firstName: 'Alicia',
 		lastName: 'Fitzgerald'
 	}),
 	w(Worker, {
+		key: 3,
 		firstName: 'Hans',
 		lastName: 'Mueller'
 	})

--- a/site/source/tutorials/003_creating_widgets/index.md
+++ b/site/source/tutorials/003_creating_widgets/index.md
@@ -330,17 +330,17 @@ Now we can update the `render` method to include some workers. Add the following
 ```ts
 const workers: DNode[] = [
 	w(Worker, {
-		key: 1,
+		key: '1',
 		firstName: 'Tim',
 		lastName: 'Jones'
 	}),
 	w(Worker, {
-		key: 2,
+		key: '2',
 		firstName: 'Alicia',
 		lastName: 'Fitzgerald'
 	}),
 	w(Worker, {
-		key: 3,
+		key: '3',
 		firstName: 'Hans',
 		lastName: 'Mueller'
 	})

--- a/site/source/tutorials/004_user_interactions/demo/finished/biz-e-corp/src/widgets/WorkerContainer.ts
+++ b/site/source/tutorials/004_user_interactions/demo/finished/biz-e-corp/src/widgets/WorkerContainer.ts
@@ -12,6 +12,7 @@ export default class WorkerContainer extends WorkerContainerBase<ThemeableProper
 	render(): DNode {
 		const workers: DNode[] = [
 			w(Worker, {
+				key: '1',
 				firstName: 'Tim',
 				lastName: 'Jones',
 				email: 'tim.jones@bizecorp.org',
@@ -22,10 +23,12 @@ export default class WorkerContainer extends WorkerContainerBase<ThemeableProper
 				]
 			}),
 			w(Worker, {
+				key: '2',
 				firstName: 'Alicia',
 				lastName: 'Fitzgerald'
 			}),
 			w(Worker, {
+				key: '3',
 				firstName: 'Hans',
 				lastName: 'Mueller'
 			})

--- a/site/source/tutorials/004_user_interactions/demo/initial/biz-e-corp/src/widgets/WorkerContainer.ts
+++ b/site/source/tutorials/004_user_interactions/demo/initial/biz-e-corp/src/widgets/WorkerContainer.ts
@@ -12,14 +12,17 @@ export default class WorkerContainer extends WorkerContainerBase<ThemeableProper
 	render(): DNode {
 		const workers: DNode[] = [
 			w(Worker, {
+				key: '1',
 				firstName: 'Tim',
 				lastName: 'Jones'
 			}),
 			w(Worker, {
+				key: '2',
 				firstName: 'Alicia',
 				lastName: 'Fitzgerald'
 			}),
 			w(Worker, {
+				key: '3',
 				firstName: 'Hans',
 				lastName: 'Mueller'
 			})


### PR DESCRIPTION
A key is needed when there are multiple widget siblings of the type.

Resolves #68 