### PR TITLE
change-hexo-root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ html-report
 /deploy_key.enc
 /support/**/*.js
 /.test
+/site/_overrides.json
+/site/_multiconfig.yml

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "headroom.js": "^0.9.3",
-    "hexo": "^3.2.0",
+    "hexo": "^3.3.1",
     "hexo-authors": "^0.1.0",
     "hexo-cli": "^1.0.2",
     "hexo-deployer-git": "^0.2.0",

--- a/support/grunt/tasks/hexo.ts
+++ b/support/grunt/tasks/hexo.ts
@@ -2,6 +2,8 @@ import IMultiTask = grunt.task.IMultiTask;
 import { exec, promisify } from '../../util/process';
 import { join } from 'path';
 import wrapAsyncTask from '../commands/wrapAsyncTask';
+import { writeFileSync } from 'fs';
+import * as env from '../../util/environment';
 
 /**
  * Builds the hexo site
@@ -9,8 +11,23 @@ import wrapAsyncTask from '../commands/wrapAsyncTask';
 export = function (grunt: IGrunt) {
 	function buildTask(this: IMultiTask<any>) {
 		const siteDirectory = this.filesSrc[0];
-		const hexoBin = join(siteDirectory, 'node_modules', '.bin', 'hexo');
-		const proc = exec(`${ hexoBin } --cwd ${ siteDirectory } generate`, { silent: false });
+		const hexoBin = join('node_modules', '.bin', 'hexo');
+		const configs = [ '_config.yml' ];
+		const options = this.options<any>({ });
+		const overrideRoot = env.hexoRootOverride();
+
+		if (options.overrides || overrideRoot) {
+			const overrides = options.overrides || {};
+
+			if (overrideRoot) {
+				overrides.root = overrideRoot;
+			}
+
+			writeFileSync(join(siteDirectory, '_overrides.json'), JSON.stringify(overrides));
+			configs.push('_overrides.json');
+		}
+
+		const proc = exec(`${ hexoBin } --config=${ configs.join(',') } generate`, { silent: false, cwd: siteDirectory });
 		return promisify(proc);
 	}
 

--- a/support/util/environment.ts
+++ b/support/util/environment.ts
@@ -55,6 +55,10 @@ export function hasGitCredentials(keyFile?: string): boolean {
 	return true;
 }
 
+export function hexoRootOverride() {
+	return process.env.HEXO_ROOT;
+}
+
 /**
  * @param file the filename of the key file used ssh+git permissions
  * @return {boolean} if the defined key file exists


### PR DESCRIPTION
Allows overriding of Hexo root using the `HEXO_ROOT` environment variable, necessary for forked deploys