### PR TITLE
ref #32: replace copied code with include_codefile task 

### DIFF
--- a/site/scripts/codefile.js
+++ b/site/scripts/codefile.js
@@ -3,7 +3,7 @@
 // File path must be a child .md file.
 
 /*
-    Usage: {% include_codefile path/to/file/relative/filename.ts [lines:1-4]|[line:4] [lang:ts] %}
+	Usage: {% include_codefile path/to/file/relative/filename.ts [lines:1-4,7]|[line:4] [lang:ts] %}
 */
 
 var fs = require('hexo-fs');
@@ -13,81 +13,96 @@ var _ = require("lodash");
 
 
 hexo.extend.tag.register('include_codefile', function(args) {
-    var filename = args[0];
-    var lang = false;
-    var lines = false;
-    var solution = false;
-    var content = '';
+	var filename = args[0];
+	var lang = false;
+	var lines = false;
+	var solution = false;
+	var content = '';
 
-    _.forEach(args.slice(1), function(arg){
-        if(_.startsWith(arg, "lang:")) {
-            lang = arg.replace("lang:", "");
-        }
-        if (_.startsWith(arg, "line")) {
-            lines = arg.replace(/([a-zA-Z]+?)(s\b|\b):/gm, "");
-            lines = cf.parseLinesRange(lines);
-        }
-        if(_.startsWith(arg, "solution:")) {
-            solution = arg.replace("solution:", "");
-        }
-    });
+	_.forEach(args.slice(1), function(arg){
+		if(_.startsWith(arg, "lang:")) {
+			lang = arg.replace("lang:", "");
+		}
+		if (_.startsWith(arg, "line")) {
+			lines = arg.replace(/([a-zA-Z]+?)(s\b|\b):/gm, "");
+			lines = cf.parseLinesRange(lines);
+		}
+		if(_.startsWith(arg, "solution:")) {
+			solution = arg.replace("solution:", "");
+		}
+	});
 
-    lang = lang ? lang : 'javascript';
+	lang = lang ? lang : 'javascript';
 
-    var rawContent = fs.readFileSync(cf.getFilePath(this.path, filename));
-    
-    if(lines !== false) {
-       content = cf.extractContent(rawContent, lines);
-    } else {
-        content = rawContent;
-    }
+	var rawContent = fs.readFileSync(cf.getFilePath(this.path, filename));
+
+	if(lines !== false) {
+	   content = cf.extractContent(rawContent, lines);
+	} else {
+		content = rawContent;
+	}
 
    var highlighted = Prism.highlight(content, Prism.languages[lang]);
-   var codeString = `<pre class="language-${lang}"><code>${highlighted}</code></pre>`;
+   var codeString = `<pre class="language-${lang}"><code class="language-${lang}">${highlighted}</code></pre>`;
 
    if(solution) {
-       return `<div class="solution-container"><button class="toggle-solution" data-target="${solution}">Toggle Solution</button><section id="${solution}" class="hidden">${codeString}</section></div>`;
+		return `<div class="solution-container"><button class="toggle-solution" data-target="${solution}">Toggle Solution</button><section id="${solution}" class="hidden">${codeString}</section></div>`;
    } else {
-       return codeString;
+	   return codeString;
    }
 
 }, { async: true });
 
 
 var cf = {
-    parseLinesRange: function (str) {
-        
-        if (str.indexOf("-") != -1) {
-            lines = str.split("-");
-            lines[0] = (lines[0]) - 1;
-        } else {
-            lines = (str) - 1;
-        }
+	parseLinesRange: function (str) {
+		var lines = {};
+		var lineGroups;
+		if (str.indexOf(',') !== -1) {
+			lineGroups = str.split(',');
+		} else {
+			lineGroups = [str];
+		}
+		lineGroups.forEach(function (lineGroup) {
+			if (lineGroup.indexOf("-") != -1) {
+				var currentLines = lineGroup.split("-").map(function(v) {
+					return parseInt(v, 10);
+				});
+				for (var i = currentLines[0]; i <= currentLines[1]; i++){
+					lines[i-1] = true;
+				}
+			} else {
+				lines[lineGroup - 1] = true;
+			}
+		});
 
-        return lines;
-    },
+		var result = Object.keys(lines).sort(function (l, r) {
+			return parseInt(l, 10) - parseInt(r, 10);
+		});
+		return result;
+	},
 
-    getFilePath: function (path, filename) {
-        var dir = path.split('/').slice(0, -1).join('/');
-        return pathFn.join(hexo.source_dir, dir, filename);
-    },
+	getFilePath: function (path, filename) {
+		var dir = path.split('/').slice(0, -1).join('/');
+		return pathFn.join(hexo.source_dir, dir, filename);
+	},
 
-    extractContent: function (rawContent, lines) {
-        var linefeed = rawContent.indexOf('\r\n') !== -1 ? '\r\n' : '\n';
-        var splitContent = rawContent.split(linefeed)
-        var fragment = "";
+	extractContent: function (rawContent, lines) {
+		var linefeed = rawContent.indexOf('\r\n') !== -1 ? '\r\n' : '\n';
+		var splitContent = rawContent.split(linefeed)
+		var fragment = '';
 
-        if (_.isArray(lines)) {
-            var lineStart = lines[0];
-            var lineEnd = lines[1];
-            var arrContent = splitContent.slice(lineStart, lineEnd);
-            _.each(arrContent, function (ln) {
-                fragment += ln + linefeed;
-            });
-        } else {
-            fragment = splitContent[lines];
-        }
+		if (_.isArray(lines)) {
+			var lineStart = lines[0];
+			var lineEnd = lines[1];
+			var arrContent = [];
+			lines.forEach(function (line) {
+				fragment += splitContent[line] + linefeed;
+			});
+		} else {
+			fragment = splitContent[lines];
+		}
 
-        return fragment;
-    }
+		return fragment;
+	}
 }

--- a/site/source/tutorials/001_static_content/index.md
+++ b/site/source/tutorials/001_static_content/index.md
@@ -35,23 +35,11 @@ Notice that, whether you are working locally or online, the page has automatical
 
 Now, let's remove the "Hello, Dojo World!" message. To do that, open up the `HelloWorld.ts` file. If you are working locally, it is located in `/src/widgets`. If, however, you are using the embedded editor then it is pinned to the bottom of your browser. You should see something like this:
 
-```typescript
-import { v } from '@dojo/widget-core/d';
-import { DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
-import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-
-export default class HelloWorld extends WidgetBase<WidgetProperties> {
-	protected render(): DNode {
-		return v('div', [ 'Hello, Dojo World!' ]);
-	}
-}
-```
+{% include_codefile 'demo/initial/biz-e-corp/src/widgets/HelloWorld.ts' %}
 
 Some of this code may not make sense now, but over the next few tutorials, you will find out what all of it means. For now, let's focus on this line:
 
-```typescript
-return v('div', [ 'Hello, Dojo World!' ]);
-```
+{% include_codefile 'demo/initial/biz-e-corp/src/widgets/HelloWorld.ts' line:7 %}
 
 The `v` function simply instructs Dojo 2 to create a HTML element, in this case a `<div>` element with the text "Hello, Dojo World!" inside of it. Now, let's replace the `<div>` tag with an `<h1>` tag. We will build a view that allows the user to view Biz-E Corp's workers, so we will add the content "Biz-E Bodies" to the document. When you are finished, click on show solution to see the results.
 
@@ -73,9 +61,7 @@ Within Dojo 2, we leverage the [Maquette](http://maquettejs.org/) virtual DOM li
 
 If we want to create a `h1` element with additional attributes, then these attributes can be passed in the second argument to the `v` function. Updating our `v` function call, with a `title` attribute would look like this:
 
-```typescript
-v('h1', { title: 'I am a title!' },[ 'Biz-E Bodies' ]);
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/HelloWorld.ts' line:7 %}
 
 Notice that we have added a parameter between the tag and content parameters. The object used as the second parameter can set any attribute on the element being created. This method of using JavaScript or TypeScript to create DOM elements is called [HyperScript](https://github.com/hyperhype/hyperscript) and is shared by many virtual DOM implementations.
 

--- a/site/source/tutorials/002_creating_an_application/index.md
+++ b/site/source/tutorials/002_creating_an_application/index.md
@@ -32,21 +32,14 @@ If you are following along locally, you can [download](../assets/002_creating_an
 ### The main HTML document
 HTML pages are the foundation for every web application, and Dojo 2 applications are no different. In the sample application, the `index.html` file serves this role. Notice that the `<body>` tag contains a single element: `<my-app>`. While there is nothing special about this element, it is important that we can uniquely identify it. To find out why, look at this line in the `main.ts` file:
 
-```ts
-const root = document.querySelector('my-app') || undefined;
-```
+{% include_codefile 'demo/initial/biz-e-corp/src/main.ts' line:4 %}
 
 Notice that we are searching for the `my-app` element and assigning it to the constant `root`. The application is using this node to determine where to place the Dojo 2 application on the page. Everything that the application does should be contained within this single element. There are several benefits to this approach. First, a Dojo 2 application can easily coexist on a page with other content. That content can consist of static assets, a legacy application or even another Dojo 2 application. The next advantage is that Dojo 2 can take leverage third-party libraries with ease. For example, if you would like to use the [moment.js](https://momentjs.com/) library to simplify working with time in your application, it can be loaded in the main HTML document, and the Dojo 2 application can take advantage of it.
 
 ### The projector
 In the [last](../001_static_content) tutorial we reviewed Dojo 2's use of a virtual DOM (Document Object Model) to provide an abstraction between the application and the rendered page. The projector is the component that serves as the intermediary between these two aspects of the application and, as such, has a presence in both the application and the main HTML document. Review these lines in the `main.ts` file:
 
-```ts
-const Projector = ProjectorMixin(HelloWorld);
-const projector = new Projector();
-
-projector.append(root);
-```
+{% include_codefile 'demo/initial/biz-e-corp/src/main.ts' lines:6-9 %}
 
 These lines are the key to allowing the projector to coordinate between the virtual DOM and the rendered HTML that the user sees. The first line creates a class that registers the `HelloWorld` widget as the root of the application, making it aware of the Dojo 2 application. An instance is then created and its `append` method is used to make the projector aware of the HTML document.
 
@@ -73,15 +66,7 @@ The final aspect that our basic application contains is its test suite. Dojo 2 i
 
 Our demo application includes some tests to verify that it is working as expected. The tests are found in `tests/unit/widgets/HelloWorld.ts`. Let's examine this part of the test code:
 
-```ts
-	'render'() {
-		const helloWorld = new HelloWorld();
-
-		const vnode = <VNode> helloWorld.__render__();
-		assert.strictEqual(vnode.vnodeSelector, 'h1');
-		assert.equal(vnode.text, 'Biz-E-Bodies');
-	}
-```
+{% include_codefile 'demo/initial/biz-e-corp/tests/unit/widgets/HelloWorld.ts' lines:8-14 %}
 
 This test is ensuring that the rendering function is returning the correct tag and that the tag has the correct content. We will return to the topic of testing in a later tutorial, but for now you can use them to check your work as you progress through this series by running the following terminal command:
 

--- a/site/source/tutorials/003_creating_widgets/index.md
+++ b/site/source/tutorials/003_creating_widgets/index.md
@@ -29,50 +29,27 @@ If you are following along locally, you can [download](../assets/003_creating_wi
 ## Creating the application widget
 In the [first tutorial](../001_static_content) in this series, we created an application with a single widget, which we modified to show the title of our Biz-E Bodies view. In this tutorial, we're going to expand our application to show each worker's portrait as well as their name. Before we get to that we have some refactoring to do. Our demo application is currently hard-wired to render our single widget, which has been renamed to the more appropriate `Banner` in this tutorial. This can be found in the `main.ts` file here:
 
-```ts
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
-import Banner from './widgets/Banner';
-
-const root = document.querySelector('my-app') || undefined;
-
-const Projector = ProjectorMixin(Banner);
-const projector = new Projector();
-
-projector.append(root);
-```
+{% include_codefile 'demo/initial/biz-e-corp/src/main.ts' %}
 
 This line: `const Projector = ProjectorMixin(Banner);` tells the application to use the `Banner` widget as the source of the virtual DOM elements for rendering the application. To add a second widget, we are going to create a new widget called `App` that represents the entire application that we are building. To start that process, go into the empty `App.ts` file located in the `src/widgets` directory. First, we need to add the required dependencies to create the `App` widget.. Add these lines at the top of the file.
 
-```ts
-import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
-import { v, w } from '@dojo/widget-core/d';
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/App.ts' lines:1-3 %}
 
 The `WidgetBase` class will be used as the base class for our `App` widget. `WidgetBase` (and its descendants) work with the `WidgetProperties` interface to define the publicly accessible properties of the widget. Finally, the `v` and `w` functions are used to render virtual DOM nodes (with the `v` function) or widgets (via `w`). Both virtual DOM nodes and widgets are rendered generate `DNode`s, the base type of all virtual DOM nodes in Dojo 2.
 
 Our next dependency to load is the Banner widget that we created in the first tutorial. To import it, add the following statement to `App.ts`:
 
-```ts
-import Banner from './Banner';
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/App.ts' line:4 %}
 
 With all of the dependencies in place, let's create the `App` widget itself:
 
-```ts
-export default class App extends WidgetBase<WidgetProperties> {
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/App.ts' line:7,14 %}
 
 Notice that the `App` class is extending `WidgetBase`, a [generic class](https://www.typescriptlang.org/docs/handbook/generics.html#generic-classes) that accepts the `WidgetProperties` interface. This will give our class several default properties and behaviors that are expected to be present in a Dojo 2 widget. Also, notice that we are have added the `export` and `default` keywords before the `class` keyword. This is the ES6 standard approach for creating modules, which Dojo 2 leverages when creating a widget - the widget should be the default export in order to make it as convenient as possible to use.
 
 Our next step is to override `WidgetBase`'s `render` method to generate the application's view. The `render` method has the following signature `protected render() : DNode`, which means that our render method has to return a `DNode` (an abstraction for an [HyperScript](https://github.com/hyperhype/hyperscript) node) so that the application's projector knows what to render. The normal way to generate this `DNode` is by calling either the `v` or `w` functions. To start, let's use the simplest `render` method by adding this to the `App` class:
 
-```ts
-protected render(): DNode {
-	return v('div', []);
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/App.ts' lines:8-9,12-13 %}
 
 This method will generate a `div` virtual node with no children. To render the `Banner` as a child of the div, we'll use the `w` function that is designed to render widgets. Update the `render` method to the following:
 
@@ -97,15 +74,11 @@ Both of these properties are optional, so we can pass an empty object for now.
 
 Our `App` class is now complete and ready to replace the `Banner` class as the root of the application. To do that, we will edit `main.ts`. The first update will replace the `import` statement from the `Banner` class to the new `App` class:
 
-```ts
-import App from './widgets/App';
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' line:2 %}
 
 The only other change we need to make is to pass the `App` class into the `ProjectorMixin` function call on line 6:
 
-```ts
-const Projector = ProjectorMixin(App);
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' line:6 %}
 
 With that change, the `App` widget is ready to serve as the root of our application. Let's test everything by building and running the project. If you are working locally, run the following command:
 
@@ -179,27 +152,15 @@ Now run the application with `dojo build --watch` and navigate to [`http://local
 
 Return to `widgets/Worker.ts` and add an interface with the custom properties that we need:
 
-```ts
-export interface WorkerProperties extends WidgetProperties {
-	firstName?: string
-	lastName?: string
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:7-10 %}
 
 Then change the generic parameter passed into `WidgetBase` with the new interface:
 
-```ts
-export default class Worker extends WidgetBase<WorkerProperties>
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' line:15 %}
 
 The `WorkerProperties` interface adds two new optional properties that we'll be able to use. Now that these are available, let's use them to make the name of the worker dynamic. Inside of the render method, add the following code to create some local constants for the first and last names:
 
-```ts
-const {
-	firstName = 'firstName',
-	lastName = 'lastName'
-} = this.properties;
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:17-20 %}
 
 This code retrieves the appropriate property and provides a reasonable default, in case the widget doesn't receive a value. We can now update the generated virtual DOM with those values by updating the returned value from the render method with those property values.
 
@@ -240,63 +201,24 @@ Dojo leverages [CSS Modules](https://github.com/css-modules/css-modules) to prov
 
 To allow our Worker widget to be styled, we need to modify the Widget class. First, apply a [decorator](https://www.typescriptlang.org/docs/handbook/decorators.html) to the class to modify the widget's constructor and prepare its instances to work with CSS modules. Also, we will apply a theme "mixin" to the Worker widget. A mixin is not intended to be used on its own, but instead works with a class to add useful functionality. Add the following import to the top of `widgets/Worker.ts`:
 
-```ts
-import { theme, ThemeableMixin } from '@dojo/widget-core/mixins/Themeable';
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' line:4 %}
 
 We also need to `import` our CSS:
-```ts
-import * as css from '../styles/worker.css';
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' line:5 %}
 
 `worker.css` contains CSS selectors and rules to be consumed by our widget and its components.
 
 With the imports in place, we can add the **@theme** decorator and apply the mixin to the `Worker` class in `widgets/Worker.ts`:
 
-```ts
-const WorkerBase = ThemeableMixin(WidgetBase);
-
-@theme(css)
-export default class Worker extends WorkerBase<WorkerProperties>
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:12-15 %}
 
 Next, let's add our CSS rules in `src/styles/` which will allow us to style the `Worker` widget:
 
-```css
-.worker {
-	width: 27%;
-	margin: 0 3%;
-	text-align: center;
-	display: inline-block;
-}
-
-.image {
-	width: 100%;
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/worker.css' lang:css %}
 
 `dojo build --watch` will detect these new rules and generate the type declaration files automatically, allowing us to apply them to the `Worker` widget. Return to `widgets/Worker.ts` and update the render method:
 
-```ts
-render(): DNode {
-	const {
-		firstName = 'firstName',
-		lastName = 'lastName'
-	} = this.properties;
-
-	return v('div', {
-		classes: this.classes(css.worker)
-	}, [
-			v('img', {
-				classes: this.classes(css.image),
-				src: 'images/worker.jpg' }, []),
-			v('div', [
-				v('strong', [ `${lastName}, ${firstName}` ])
-			])
-		]
-	);
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:16-33 %}
 
 If you return to the browser, you'll see that the widget now has the classes applied and looks a little better. While you are there, open up the developer tools and look at the CSS classes that have been applied to the widget's components. Notice that we don't have class names such as `.worker` or `.image` like we used in the CSS file, rather we have something like `.worker__image__3aIJl`. This obfuscation is done by the `dojo build` command's use of CSS Modules when it compiles the project to ensure that CSS selectors are localized to a given widget. There are also ways to provide global styling rules (called "themes"). To learn more about those, take a look at the [Theming an Application](../comingsoon.html) tutorial in the Cookbook section.
 
@@ -327,25 +249,7 @@ export default class WorkerContainer extends WorkerContainerBase<ThemeableProper
 
 Now we can update the `render` method to include some workers. Add the following to the top of the `render` method:
 
-```ts
-const workers: DNode[] = [
-	w(Worker, {
-		key: '1',
-		firstName: 'Tim',
-		lastName: 'Jones'
-	}),
-	w(Worker, {
-		key: '2',
-		firstName: 'Alicia',
-		lastName: 'Fitzgerald'
-	}),
-	w(Worker, {
-		key: '3',
-		firstName: 'Hans',
-		lastName: 'Mueller'
-	})
-];
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/WorkerContainer.ts' lines:13-29 %}
 
 Notice that we have added an `id` property to each child. This is needed so that we can differentiate between the children.
 If you add multiple children that have the same tag name, e.g. `div` or widget name, e.g. `Worker`, then you will need to add a property that makes each child unique.
@@ -353,39 +257,15 @@ In the code example shown above, we have added an `id` property and set the valu
 
 We can now pass these workers as children to the container, by replacing the empty array in the `v` function's third argument with this array:
 
-```ts
-return v('div', {
-	classes: this.classes(styles.container)
-}, workers);
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/WorkerContainer.ts' lines:31-33 %}
 
 Now it is time to add the `container` CSS rule inside `styles/workerContainer.css`:
 
-```css
-.container {
-	width: 80%;
-	margin: 0 auto;
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/workerContainer.css' lang:css %}
 
 Finally, let's update the `App` class to replace the `Worker` widget with the new `WorkerContainer`.
 
-```ts
-import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
-import { v, w } from '@dojo/widget-core/d';
-import Banner from './Banner';
-import WorkerContainer from './WorkerContainer';
-
-export default class App extends WidgetBase<WidgetProperties> {
-	protected render(): DNode {
-		return v('div', [
-			w(Banner, {}),
-			w(WorkerContainer, {})
-		]);
-	}
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/App.ts' %}
 
 The application now renders three workers in the `WorkerContainer` widget, allowing us to control how they are laid out without impacting the overall application.
 

--- a/site/source/tutorials/004_user_interactions/index.md
+++ b/site/source/tutorials/004_user_interactions/index.md
@@ -89,174 +89,39 @@ Now that we have an event handler it is time to extend the `render` method to be
 
 We could add the additional rendering logic in the current `render` method, but that method could become difficult to maintain as it would have to contain all of the rendering code for both the front and back of the card. Instead, we will generate the two views using two private methods and then call them from the `render` method. To start, create a new private method called `_renderFront` and move the existing render code inside it::
 
-```ts
-private _renderFront(): DNode {
-	const {
-		firstName = 'firstName',
-		lastName = 'lastName'
-	} = this.properties;
-
-	return v('div', {
-		classes: this.classes(css.workerFront),
-		onclick: this.flip
-	}, [
-		v('img', {
-			classes: this.classes(css.image),
-				src: 'images/worker.jpg' }, []),
-			v('div', [
-				v('strong', [ `${lastName}, ${firstName}` ])
-			])
-		]
-	);
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:25-43 %}
 
 Next, create another private method called `_renderBack` to render the back view:
-```ts
-private _renderBack(): DNode {
-	const {
-		firstName = 'firstName',
-		lastName = 'lastName',
-		email = 'unavailable',
-		timePerTask = 0,
-		tasks = []
-	} = this.properties;
 
-	return v('div', {
-		classes: this.classes(css.workerBack),
-		onclick: this.flip
-		}, [
-			v('img', {
-					classes: this.classes(css.imageSmall),
-					src: 'images/worker.jpg'
-				}, []
-			),
-			v('div', {
-				classes: this.classes(css.generalInfo)
-			}, [
-				v('div', {
-					classes : this.classes(css.label)
-				}, ['Name']),
-				v('div', [`${lastName}, ${firstName}`]),
-				v('div', {
-					classes: this.classes(css.label)
-				}, ['Email']),
-				v('div', [`${email}`]),
-				v('div', {
-					classes: this.classes(css.label)
-				}, ['Avg. Time per Task']),
-				v('div', [`${timePerTask}`])
-			]),
-			v('div', [
-				v('strong', ['Current Tasks']),
-				v('div', tasks.map(task => {
-					return v('div', {
-							classes: this.classes(css.task)
-						},
-						[task]
-					);
-				}))
-			])
-		]
-	);
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:45-91 %}
 
 None of this code is new. We are composing together multiple virtual nodes to generate the elements required to render the detailed view. This method does, however, refer to some properties and CSS selectors that do not exist yet.
 
 Three new properties need to be added to the `WorkerProperties` interface. These properties are the email address of the worker, the average number of hours they take to complete a task, and the active tasks for the worker..  Update the `WorkerProperties` interface to:
 
-```ts
-export interface WorkerProperties extends WidgetProperties {
-	firstName?: string
-	lastName?: string
-	email?: string
-	timePerTask?: number
-	tasks?: string[]
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:7-13 %}
 
 Now, we need to add the CSS selectors that will provide the rules for rendering this view's elements. Open up the `worker.css` file in `src/styles` and update it as follows:
 
-```css
-.workerFront {
-	width: 27%;
-	margin: 0 3%;
-	display: inline-block;
-	vertical-align: top;
-	text-align: center;
-}
-
-.workerBack {
-	width: 27%;
-	margin: 0 3%;
-	display: inline-block;
-	vertical-align: top;
-	font-size: 0.5em;
-}
-
-.image {
-	width: 100%;
-}
-
-.imageSmall {
-	width: 40%;
-}
-
-.generalInfo {
-	width: 55%;
-	display: inline-block;
-}
-
-.task {
-	border: solid 1px #333;
-	border-radius: 0.3em;
-	text-align: left;
-}
-
-.label {
-	font-weight: bold;
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/worker.css' lines:8-39 lang:css %}
 
 We also need to update the CSS selector for the front view, by changing the selector from `css.worker` to `css.workerFront`.
 
-```ts
-private _renderFront(): DNode {
-	const {
-		firstName="firstName",
-		lastName="lastName"} = this.properties;
-
-	return v('div', {
-		classes: this.classes(css.workerFront),
-		onclick: this.flip
-	},...
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:25-43 %}
 
 Finally, we need to update the `render method` to choose between the two rendering methods. To do that, add a private field to the class:
 
-```ts
-private _isFlipped = false;
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' line:19 %}
 
 The use of a field to store this kind of data is standard practice in Dojo 2. Properties are used to allow other components to view and modify a widget's published state. For internal state, however, private fields are used to allow widget to encapsulate state information that should not be exposed publicly. Let's use that field's value to determine which side to show:
 
-```ts
-protected render(): DNode {
-	return this._isFlipped ? this._renderBack() : this._renderFront();
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:21-23 %}
 
 Confirm that everything is working by viewing the application in a browser - all three cards should be showing their front faces. Now change the value of the `_isFlipped` field to `true` and, after the application recompiles, all three widgets should be showing their back faces.
 
 In order to re-render our widget, we need to update the `flip` method to toggle the `_isFlipped` field and invalidate the widget
 
-```ts
-flip(): void {
-	this._isFlipped = !this._isFlipped;
-	this.invalidate();
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:93-96 %}
 
 Now, the widget can be flipped between its front and back sides by clicking on it.
 


### PR DESCRIPTION
also updated codefile.js to allow lines to be provided via comma delimited sets of single lines and groups (e.g. `lines:1-4,7,9-11`)