### PR TITLE
update URLs and links throughout tutorials to standardize on paths with trailing slash

### DIFF
--- a/site/scripts/aside.js
+++ b/site/scripts/aside.js
@@ -1,3 +1,0 @@
-hexo.extend.tag.register('aside', function(args, content) {
-	return `<article class='aside'>${content}</article>`;
-}, {ends: true});

--- a/site/scripts/aside.js
+++ b/site/scripts/aside.js
@@ -1,0 +1,3 @@
+hexo.extend.tag.register('aside', function(args, content) {
+	return `<article class='aside'>${content}</article>`;
+}, {ends: true});

--- a/site/source/tutorials/001_static_content/index.md
+++ b/site/source/tutorials/001_static_content/index.md
@@ -10,9 +10,9 @@ overview: In this tutorial, you will learn how to the create your first Dojo 2 a
 In this tutorial, you will learn how to the create your first Dojo 2 application and use it to print a simple message in the browser.
 
 ## Prerequisites
-You can [download](./assets/001_static_content-initial.zip) the demo project to get started.
+You can [download](../assets/001_static_content-initial.zip) the demo project to get started.
 
-You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](./comingsoon.html) article.
+You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](../comingsoon.html) article.
 
 ## Printing static content
 
@@ -52,7 +52,7 @@ Now, let's look at the `v` function again. We're intentionally avoiding somethin
 
 In traditional web applications, keeping the DOM and JavaScript application logic in sync led to significant complexity and inefficiency for non-trivial applications. When building applications with numerous changes to state and data, the virtual DOM approach can greatly simplify your application logic and improve performance. A virtual DOM serves as an intermediary between your application logic and what is rendered in the real DOM on the page.
 
-Within Dojo 2, we leverage the [Maquette](http://maquettejs.org/) virtual DOM library to determine the most efficient way to interact with the DOM elements in your view. An additional benefit of the virtual DOM is that it facilitates a reactive programming style which simplifies your application. To learn more about the virtual DOM or reactive programming in Dojo 2, check out the [Working with a Virtual DOM](./comingsoon.html) and [Reactive Programming](./comingsoon.html) articles in the reference section. For now, let's get back to our application and make some more changes.
+Within Dojo 2, we leverage the [Maquette](http://maquettejs.org/) virtual DOM library to determine the most efficient way to interact with the DOM elements in your view. An additional benefit of the virtual DOM is that it facilitates a reactive programming style which simplifies your application. To learn more about the virtual DOM or reactive programming in Dojo 2, check out the [Working with a Virtual DOM](../comingsoon.html) and [Reactive Programming](../comingsoon.html) articles in the reference section. For now, let's get back to our application and make some more changes.
 
 If we want to create a `h1` element with additional attributes, then these attributes can be passed in the second argument to the `v` function. Updating our `v` function call, with a `title` attribute would look like this:
 
@@ -60,6 +60,6 @@ If we want to create a `h1` element with additional attributes, then these attri
 
 Notice that we have added a parameter between the tag and content parameters. The object used as the second parameter can set any attribute on the element being created. This method of using JavaScript or TypeScript to create DOM elements is called [HyperScript](https://github.com/hyperhype/hyperscript) and is shared by many virtual DOM implementations.
 
-Congratulations! You are off to a good start on your journey to master Dojo 2. In the [next tutorial](./002_creating_an_application), we will start to get familiar with the major components of a Dojo 2 application.
+Congratulations! You are off to a good start on your journey to master Dojo 2. In the [next tutorial](../002_creating_an_application/), we will start to get familiar with the major components of a Dojo 2 application.
 
-If you would like, you can download the completed [demo application](./assets/001_static_content-finished.zip) from this tutorial.
+If you would like, you can download the completed [demo application](../assets/001_static_content-finished.zip) from this tutorial.

--- a/site/source/tutorials/002_creating_an_application/index.md
+++ b/site/source/tutorials/002_creating_an_application/index.md
@@ -7,12 +7,12 @@ overview: In this tutorial, you will learn about the structure of a simple Dojo 
 # Building your first Dojo 2 application
 
 ## Overview
-In this tutorial, you will learn about the structure of a simple Dojo 2 application and the purpose of each part of the application. This will not be a comprehensive discussion about all of the parts that can potentially be a part of a Dojo 2 application. Instead, we are going to focus on the minimum application that we started with in the [previous tutorial](./001_static_content).
+In this tutorial, you will learn about the structure of a simple Dojo 2 application and the purpose of each part of the application. This will not be a comprehensive discussion about all of the parts that can potentially be a part of a Dojo 2 application. Instead, we are going to focus on the minimum application that we started with in the [previous tutorial](../001_static_content/).
 
 ## Prerequisites
-You can [download](./assets/002_creating_an_application-initial.zip) the demo project to get started.
+You can [download](../assets/002_creating_an_application-initial.zip) the demo project to get started.
 
-You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](./comingsoon.html) article.
+You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](../comingsoon.html) article.
 
 ## Components of a Dojo 2 application
 
@@ -24,7 +24,7 @@ HTML pages are the foundation for every web application and Dojo 2 applications 
 Notice that we are searching for the `my-app` element and assigning it to the constant `root`. The application is using this node to determine where to place the Dojo 2 application on the page. Everything that the application does should be contained within this single element. There are several benefits to this approach. First, a Dojo 2 application can easily coexist on a page with other content. That content can consist of static assets, a legacy application or even another Dojo 2 application. The next advantage is that Dojo 2 can take leverage third-party libraries with ease. For example, if you would like to use the [moment.js](https://momentjs.com/) library to simplify working with time in your application, it can be loaded in the main HTML document, and the Dojo 2 application can take advantage of it.
 
 ### The projector
-In the [last](./001_static_content) tutorial we reviewed Dojo 2's use of a virtual DOM (Document Object Model) to provide an abstraction between the application and the rendered page. The projector is the component that serves as the intermediary between these two aspects of the application and, as such, has a presence in both the application and the main HTML document. Review these lines in the `main.ts` file:
+In the [last](../001_static_content/) tutorial we reviewed Dojo 2's use of a virtual DOM (Document Object Model) to provide an abstraction between the application and the rendered page. The projector is the component that serves as the intermediary between these two aspects of the application and, as such, has a presence in both the application and the main HTML document. Review these lines in the `main.ts` file:
 
 {% include_codefile 'demo/initial/biz-e-corp/src/main.ts' lines:6-9 %}
 
@@ -35,7 +35,7 @@ Whenever a Dojo 2 application needs to update the view, it informs the projector
 ### Widgets
 Widgets are the basic building blocks of Dojo 2's user interface. They combine both the visual and behavioral aspects of a component into a single element. Both of these aspects are encapsulated within the widget's implementation. The widget then exposes properties and methods that allow other components to interact with it. Consider the following diagrams:
 
-<img src="./resources/html_js.svg" title="HTML and JavaScript" class="half-width"/><img src="./resources/widget.svg" title="Widget" class="half-width"/>
+<img src="../resources/html_js.svg" title="HTML and JavaScript" class="half-width"/><img src="../resources/widget.svg" title="Widget" class="half-width"/>
 
 The first diagram shows a traditional HTML + JavaScript architecture. Since the the visual (HTML) and behavioral (JavaScript) aspects of the application are publicly accessible, the application's components can be manipulated directly which can lead to the HTML and JavaScript getting out of sync with each other. Extensive test suites are often needed to make sure that this does not happen.
 
@@ -63,4 +63,4 @@ dojo test
 ## Summary
 This tutorial introduced the components that make up the core of every Dojo 2 application. While there are many other components that are optional, the main HTML document, projector, widgets and, hopefully, tests are will be present in all of them.
 
-In the [next tutorial](./003_creating_widgets), we will take a deeper look at Dojo 2 widgets. We'll go beyond the static widgets that we have worked with so far and learn how to create widgets that encapsulate state and behavior.
+In the [next tutorial](../003_creating_widgets/), we will take a deeper look at Dojo 2 widgets. We'll go beyond the static widgets that we have worked with so far and learn how to create widgets that encapsulate state and behavior.

--- a/site/source/tutorials/003_creating_widgets/index.md
+++ b/site/source/tutorials/003_creating_widgets/index.md
@@ -10,12 +10,12 @@ overview: In this tutorial, you will learn how to create and style custom widget
 In this tutorial, you will learn how to create and style custom widgets in Dojo 2.
 
 ## Prerequisites
-You can [download](./assets/003_creating_widgets-initial.zip) the demo project to get started.
+You can [download](../assets/003_creating_widgets-initial.zip) the demo project to get started.
 
-You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](./comingsoon.html) article.
+You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](../comingsoon.html) article.
 
 ## Creating the application widget
-In the [first tutorial](./001_static_content) in this series, we created an application with a single widget, which we modified to show the title of our Biz-E Bodies view. In this tutorial, we're going to expand our application to show each worker's portrait as well as their name. Before we get to that, we have some refactoring to do. Our demo application is currently hard-wired to render our widget, which has been renamed to the more appropriate `Banner` in this tutorial. This can be found in the `main.ts` file here:
+In the [first tutorial](../001_static_content/) in this series, we created an application with a single widget, which we modified to show the title of our Biz-E Bodies view. In this tutorial, we're going to expand our application to show each worker's portrait as well as their name. Before we get to that, we have some refactoring to do. Our demo application is currently hard-wired to render our widget, which has been renamed to the more appropriate `Banner` in this tutorial. This can be found in the `main.ts` file here:
 
 {% include_codefile 'demo/initial/biz-e-corp/src/main.ts' %}
 
@@ -171,7 +171,7 @@ protected render(): DNode {
 }
 ```
 
-The final step in creating this widget is to update the `render` method in the `App` class to pass in some properties. In a full Dojo 2 application, these values would normally be retrieved from a store, but for now, we'll just use static properties. To learn more about working stores in Dojo 2, take a look at the [dojo/stores](./comingsoon.html) tutorial in the advanced section.
+The final step in creating this widget is to update the `render` method in the `App` class to pass in some properties. In a full Dojo 2 application, these values would normally be retrieved from a store, but for now, we'll just use static properties. To learn more about working stores in Dojo 2, take a look at the [dojo/stores](../comingsoon.html) tutorial in the advanced section.
 
 In `App.ts`, update the line that is rendering the `Worker` to contain values for the `firstName` and `lastName` properties:
 
@@ -208,7 +208,7 @@ Next, let's add our CSS rules in `src/styles/worker.css` which will allow us to 
 
 {% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' lines:16-33 %}
 
-If you return to the browser, you'll see that the widget now has the classes applied and looks a little better. While you are there, open up the developer tools and look at the CSS classes that have been applied to the widget's components. Notice that we don't have class names such as `.worker` or `.image` like we used in the CSS file, rather we have something like `.worker__image__3aIJl`. This obfuscation is done by the `dojo build` command's use of CSS Modules when it compiles the project to ensure that CSS selectors are localized to a given widget. There are also ways to provide global styling rules (called "themes"). To learn more about those, take a look at the [Theming an Application](./comingsoon.html) tutorial in the Cookbook section.
+If you return to the browser, you'll see that the widget now has the classes applied and looks a little better. While you are there, open up the developer tools and look at the CSS classes that have been applied to the widget's components. Notice that we don't have class names such as `.worker` or `.image` like we used in the CSS file, rather we have something like `.worker__image__3aIJl`. This obfuscation is done by the `dojo build` command's use of CSS Modules when it compiles the project to ensure that CSS selectors are localized to a given widget. There are also ways to provide global styling rules (called "themes"). To learn more about those, take a look at the [Theming an Application](../comingsoon.html) tutorial in the Cookbook section.
 
 We've almost achieved our goal of displaying a collection of Biz-E Bodies, but we have one task remaining. We could certainly add additional `Worker` widgets to our application, but they would all be siblings of the `Banner` widget and could be difficult to style properly. In the next section, we'll create a simple container widget that will manage the layout of the `Worker` widgets.
 
@@ -261,6 +261,6 @@ In this tutorial, we have created and styled widgets within Dojo 2. Widgets are 
 
 Additionally, we learned how to style widgets by using CSS modules. These modules provide all of the flexibility of CSS with the additional advantages of providing strongly typed and localized class names that allow a widget to be styled without the risk of affecting other aspects of the application.
 
-If you would like, you can download the completed [demo application](./assets/003_creating_widgets-finished.zip).
+If you would like, you can download the completed [demo application](../assets/003_creating_widgets-finished.zip).
 
-In the [next tutorial](./004_user_interactions), we will explore the how to add event handlers to allow our application to respond to user interactions.
+In the [next tutorial](../004_user_interactions/), we will explore the how to add event handlers to allow our application to respond to user interactions.

--- a/site/source/tutorials/004_user_interactions/index.md
+++ b/site/source/tutorials/004_user_interactions/index.md
@@ -11,12 +11,12 @@ In this tutorial, you will learn how to update an application in response to use
 We will start with an application that renders widgets containing the portrait and names of several employees for the hypothetical company, "Biz-E Corp". In this tutorial, you will learn how to add event listeners to these widgets so that they show additional information about each worker including a list of their active tasks.
 
 ## Prerequisites
-You can [download](./assets/004_user_interactions-initial.zip) the demo project to get started.
+You can [download](../assets/004_user_interactions-initial.zip) the demo project to get started.
 
-You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](./comingsoon.html) article.
+You also need to be familiar with TypeScript as Dojo 2 uses it extensively. For more information, refer to the [TypeScript and Dojo 2](../comingsoon.html) article.
 
 ## Creating an event listener
-In the [previous](./003_creating_widgets) tutorial in this series, we created an application that contains several widgets that render worker information. In this tutorial, you will add event listeners to these widgets to show additional information about an employee when the widget is clicked.
+In the [previous](../003_creating_widgets/) tutorial in this series, we created an application that contains several widgets that render worker information. In this tutorial, you will add event listeners to these widgets to show additional information about an employee when the widget is clicked.
 
 The first step is to add the listener itself. In Dojo 2, an event listener is assigned like any other property that is passed to the rendering function, `v`. Look at the `Worker` widget that is in `src/widgets`. Currently, the top level `DNode` has one property assigned: `classes`. Update the object containing that property as follows:
 
@@ -155,6 +155,6 @@ w(Worker, {
 
 In this tutorial, we learned how to attach event listeners to respond to widget-generated events. Event handlers are assigned to virtual nodes like any other Dojo 2 property. Be aware that the value of an event handler cannot change once the widget has been rendered the first time. This is normally accomplished by creating a method on the widget class and assigning this method as the event handler.
 
-If you would like, you can download the [demo application](./assets/004_user_interactions-finished.zip).
+If you would like, you can download the [demo application](../assets/004_user_interactions-finished.zip).
 
-In the [next tutorial](./comingsoon.html), we will work with more complicated interactions in Dojo 2 by extending the demo application, allowing new Workers to be created using forms.
+In the [next tutorial](../comingsoon.html), we will work with more complicated interactions in Dojo 2 by extending the demo application, allowing new Workers to be created using forms.

--- a/site/themes/dojo/layout/_page/tutorials.ejs
+++ b/site/themes/dojo/layout/_page/tutorials.ejs
@@ -6,7 +6,7 @@
 
 	_.each(tuts, function(tut) {
 		// remove index.html from the path to make relative URLs work consistently
-		var urlRaw = tut.path.substr(0, tut.path.length - 11 /* length of '/index.html' */);
+		var urlRaw = tut.path.substr(0, tut.path.length - 10 /* length of 'index.html' */);
 %>
 	<div class="tutorial-item">
 		<h4><a href="<%- url_for(urlRaw) %>"><%- tut.title %></a></h4>


### PR DESCRIPTION
Two URL conventions are currently being used through the tutorials, one assumed that paths would end in a trailing slash and the other assumes that this slash is absent. This makes relative URLs in links behave inconsistently. This PR will standardize URLs and links to end with a slash.