### PR TITLE
Ui and nav updates

### DIFF
--- a/site/themes/dojo/source/css/_variables.styl
+++ b/site/themes/dojo/source/css/_variables.styl
@@ -46,8 +46,8 @@ scale = 0 400px 600px 800px 1050px
 
 //Max width of outer container
 $max-width = 1280px;
-$content-max-width = 900px;
-$article-max-width = 900px;
+$content-max-width = 1280px;
+$article-max-width = 1280px;
 
 
 $logo-size = rem(40px);

--- a/site/themes/dojo/source/css/_views/tutorial.styl
+++ b/site/themes/dojo/source/css/_views/tutorial.styl
@@ -161,6 +161,13 @@
 
 			.section-container {
 				margin-top: 15px;
+				position: relative;
+				left: 50%;
+				display: inline-block;
+              	.center-section-container {
+					position: relative;
+					left: -50%;
+				}
 
 				.section-selector {
 					width: 0.7rem;
@@ -185,6 +192,12 @@
 				position: absolute;
 				right: 2rem;
 				top:7.5px;
+			}
+
+			button.previous {
+				position: absolute;
+				left: 2rem;
+				top: 7.5px;
 			}
 		}
 	}

--- a/site/themes/dojo/source/css/_views/tutorial.styl
+++ b/site/themes/dojo/source/css/_views/tutorial.styl
@@ -161,12 +161,14 @@
 
 			.section-container {
 				margin-top: 15px;
-				position: relative;
-				left: 50%;
 				display: inline-block;
-              	.center-section-container {
+              	@media(min-width: 601px) {
 					position: relative;
-					left: -50%;
+					left: 50%;
+					.center-section-container {
+						position: relative;
+						left: -50%;
+					}
 				}
 
 				.section-selector {
@@ -194,8 +196,11 @@
 				top:7.5px;
 			}
 
-			button.previous {
-				position: absolute;
+			button.back {
+				@media(max-width: 600px) {
+					display: none;
+				}
+                position: absolute;
 				left: 2rem;
 				top: 7.5px;
 			}

--- a/site/themes/dojo/source/js/tutorial-support.js
+++ b/site/themes/dojo/source/js/tutorial-support.js
@@ -63,8 +63,6 @@ tutorial.populateActionBar = function(container) {
 	}
 
 	ownEditorButton.addEventListener('click', function () {
-		sectionOneContainer.classList.add('hidden');
-		otherSectionContainer.classList.remove('hidden');
 		activateSelector(document.querySelector('.section-selector[data-section-num="1"]'));
 	});
 
@@ -84,8 +82,15 @@ tutorial.populateActionBar = function(container) {
 	nextButton.addEventListener('click', function () {
 		navigate(1);
 	});
+
+	parseActiveSection();
+	window.addEventListener('hashchange', parseActiveSection);
+
 	function activateSelector(target) {
 		var sectionToActivate = (target.getAttribute && target.getAttribute('data-section-num')) || target;
+		if (window.history.state !== sectionToActivate) {
+			window.history.pushState(sectionToActivate, '', '#' + sectionToActivate);
+		}
 
 		sectionSelectors.forEach(function (sectionSelector) {
 			if (sectionSelector === target) {
@@ -125,6 +130,9 @@ tutorial.populateActionBar = function(container) {
 			if (!sectionToActivateNum) {
 				sectionOneContainer.classList.remove('hidden');
 				otherSectionContainer.classList.add('hidden');
+			} else {
+				sectionOneContainer.classList.add('hidden');
+				otherSectionContainer.classList.remove('hidden');
 			}
 		}, 300, sectionToActivate);
 	}
@@ -139,5 +147,14 @@ tutorial.populateActionBar = function(container) {
 		}
 		var newSelector = document.querySelector('.section-selector[data-section-num="' + sectionNumber + '"]');
 		activateSelector(newSelector || '0');
+	}
+
+	function parseActiveSection() {
+		var urlSectionSegment = window.location.href.split('/').pop();
+		var pageSection = (urlSectionSegment && urlSectionSegment[0] === '#' && urlSectionSegment.slice(1)) || '0';
+		activateSelector(
+			document.querySelector('.section-selector[data-section-num="' + pageSection + '"]') || pageSection
+		);
+
 	}
 };

--- a/site/themes/dojo/source/js/tutorial-support.js
+++ b/site/themes/dojo/source/js/tutorial-support.js
@@ -20,9 +20,18 @@ tutorial.populateActionBar = function(container) {
 	ownEditorButton.innerHTML = 'Begin tutorial';
 	sectionOneContainer.appendChild(ownEditorButton);
 
+	var backButton = document.createElement('button');
+	backButton.classList.add('previous', 'green');
+	backButton.innerHTML = 'Back';
+	otherSectionContainer.appendChild(backButton);
+
 	var sections = document.querySelectorAll('section.tutorial');
 	var sectionContainer = document.createElement('div');
+	var centerSectionContainer = document.createElement('div');
+	centerSectionContainer.className = 'center-section-container';
 	sectionContainer.className = 'section-container';
+
+	sectionContainer.appendChild(centerSectionContainer);
 	otherSectionContainer.appendChild(sectionContainer);
 
 	var nextButton = document.createElement('button');
@@ -35,11 +44,11 @@ tutorial.populateActionBar = function(container) {
 	// create each section selector and link it to its section via data-section-num
 	if (sections.length > 0) {
 		for (var i = 0; i < sections.length; i++) {
+			sections[i].setAttribute('data-section-num', i);
 			if (i === 0) {
 				sections[i].classList.remove('hidden', 'hiding');
 				continue;
 			}
-			sections[i].setAttribute('data-section-num', i);
 			var sectionSelector = document.createElement('div');
 			sectionSelector.setAttribute('data-section-num', i);
 			sectionSelector.className = 'section-selector';
@@ -48,7 +57,7 @@ tutorial.populateActionBar = function(container) {
 				sectionSelector.title = title.textContent;
 			}
 
-			sectionContainer.appendChild(sectionSelector);
+			centerSectionContainer.appendChild(sectionSelector);
 			sectionSelectors.push(sectionSelector);
 		}
 	}
@@ -59,7 +68,7 @@ tutorial.populateActionBar = function(container) {
 		activateSelector(document.querySelector('.section-selector[data-section-num="1"]'));
 	});
 
-	sectionContainer.addEventListener('click', function (e) {
+	centerSectionContainer.addEventListener('click', function (e) {
 		var target = e.target;
 		// short-circuit if clicked section is already active
 		if (target.classList.contains('active')) {
@@ -68,26 +77,15 @@ tutorial.populateActionBar = function(container) {
 		activateSelector(target);
 	});
 
-	nextButton.addEventListener('click', function () {
-		var activeSelector = document.querySelector('.section-selector.active');
-		var sectionNumber = 0;
-		if (activeSelector) {
-			sectionNumber = parseInt(activeSelector.getAttribute('data-section-num'), 10) + 1;
-		} else {
-			sectionNumber = 1;
-		}
-		var newSelector = document.querySelector('.section-selector[data-section-num="' + sectionNumber + '"]');
-		if (!newSelector) {
-			return;
-		}
-		activateSelector(newSelector);
-
-
-
+	backButton.addEventListener('click', function () {
+		navigate(-1);
 	});
 
+	nextButton.addEventListener('click', function () {
+		navigate(1);
+	});
 	function activateSelector(target) {
-		var sectionToActivate = target.getAttribute('data-section-num');
+		var sectionToActivate = (target.getAttribute && target.getAttribute('data-section-num')) || target;
 
 		sectionSelectors.forEach(function (sectionSelector) {
 			if (sectionSelector === target) {
@@ -99,7 +97,8 @@ tutorial.populateActionBar = function(container) {
 
 		for (var i = 0; i < sections.length; i++) {
 			var section = sections[i];
-			if (section.getAttribute('data-section-num') === sectionToActivate) {
+			const sectionNum = section.getAttribute('data-section-num');
+			if (sectionNum === sectionToActivate) {
 				section.classList.remove('hidden');
 			} else {
 				section.classList.add('hiding');
@@ -117,12 +116,28 @@ tutorial.populateActionBar = function(container) {
 			}
 			document.querySelector('.scrollable').scrollTop = 0;
 
-			if (parseInt(sectionToActivate, 10) === sections.length - 1) {
+			var sectionToActivateNum = sectionToActivate && parseInt(sectionToActivate, 10);
+			if (sectionToActivateNum === sections.length - 1) {
 				nextButton.classList.add('hidden');
 			} else {
 				nextButton.classList.remove('hidden');
 			}
+			if (!sectionToActivateNum) {
+				sectionOneContainer.classList.remove('hidden');
+				otherSectionContainer.classList.add('hidden');
+			}
 		}, 300, sectionToActivate);
 	}
 
-}
+	function navigate(moveBy) {
+		var activeSelector = document.querySelector('.section-selector.active');
+		var sectionNumber = 0;
+		if (activeSelector) {
+			sectionNumber = parseInt(activeSelector.getAttribute('data-section-num'), 10) + moveBy;
+		} else {
+			sectionNumber = 1;
+		}
+		var newSelector = document.querySelector('.section-selector[data-section-num="' + sectionNumber + '"]');
+		activateSelector(newSelector || '0');
+	}
+};

--- a/site/themes/dojo/source/js/tutorial-support.js
+++ b/site/themes/dojo/source/js/tutorial-support.js
@@ -21,7 +21,7 @@ tutorial.populateActionBar = function(container) {
 	sectionOneContainer.appendChild(ownEditorButton);
 
 	var backButton = document.createElement('button');
-	backButton.classList.add('previous', 'green');
+	backButton.classList.add('back', 'green');
 	backButton.innerHTML = 'Back';
 	otherSectionContainer.appendChild(backButton);
 


### PR DESCRIPTION
Partially addresses #149 

This adds a back button that will go to the previous tutorial section or the tutorial overview page if already on the first page. On screens smaller than 600 pixels, a having both buttons feels very cramped so the previous UI is still used. A further improvement might be to just eliminate the navigation UI and allow the user to scroll through the entirety of the content for tablet and mobile size screens.

Also appends a `#{sectionNumber}` to the URL, parses the URL to determine the section to display based on this part of the URL, and updates the browser history when navigating between sections. As a result the forward and back browser buttons can be used to navigate through the tutorials and a specific section can be bookmarked.

Finally this increases the max width of the tutorial content from 900px to 1280px
![image](https://user-images.githubusercontent.com/5474358/28952799-b2d72714-78a1-11e7-8423-5dd81406956d.png)
