### PR TITLE
Update grunt dojo2 extras version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-dojo2": "^2.0.0-beta.39",
-    "grunt-dojo2-extras": "^2.0.0-beta1.2",
+    "grunt-dojo2-extras": "^2.0.0-beta1.3",
     "grunt-shell": "^2.1.0",
     "grunt-tslint": "^4.0.1",
     "intern": "^3.4.3",


### PR DESCRIPTION
Locally this resolves the issues causing #160 . But there was also a 403 error on the most recent build so there may be more than one issue at play.