### PR TITLE
Link to version of docs corresponding to an npm tag

### DIFF
--- a/support/commands/getApiPackages.ts
+++ b/support/commands/getApiPackages.ts
@@ -1,6 +1,8 @@
 import { readdirSync, lstatSync } from 'fs';
 import { join } from 'path';
 import * as semver from 'semver';
+import { exec } from 'grunt-dojo2-extras/src/util/process';
+import { toString } from 'grunt-dojo2-extras/src/util/streams';
 
 export interface DocumentedApi {
 	format: 'html' | 'json';
@@ -9,25 +11,49 @@ export interface DocumentedApi {
 	versions: string[];
 }
 
+export interface NpmTag {
+	scope: string;
+	tag: string;
+}
+
 /**
  * Provides information on installed API packages
  * @param apiDirectory the directory where packages reside
+ * @param npmTags Optional NPM tags to use to determine the appropriate version to display
  */
-export default function getApiPackages(apiDirectory: string): DocumentedApi[] {
-	return readdirSync(apiDirectory).filter(function (file: string) {
+export default function getApiPackages(apiDirectory: string, npmTags: { [ dir: string ]: NpmTag } = {}): Promise<DocumentedApi[]> {
+	return Promise.all(readdirSync(apiDirectory).filter(function (file: string) {
 		const stat = lstatSync(join(apiDirectory, file));
 		return stat.isDirectory() && file.charAt(0) !== '_';
 	}).map(function (dir: string) {
 		const versions = readdirSync(join(apiDirectory, dir))
 			.filter(dir => { return semver.clean(dir); })
 			.sort(semver.compare);
-		const latest = versions.length ? versions[versions.length - 1] : null;
 
+		let latest: string | null = versions.length ? versions[versions.length - 1] : null;
+		if (npmTags[dir]) {
+			const { scope, tag } = npmTags[dir];
+			const proc = exec(`npm view ${scope}/${dir}@${tag} version`, { silent: true });
+			return toString(proc.stdout).then(version => version.trim())
+				.then(tagVersion => {
+					for (let version of versions) {
+						if (semver.eq(version, tagVersion)) {
+							latest = version;
+						}
+					}
+					return {
+						format: 'html',
+						latest,
+						package: dir,
+						versions
+					} as DocumentedApi;
+				});
+		}
 		return <DocumentedApi> {
 			format: 'html',
 			latest,
 			package: dir,
 			versions
 		};
-	});
+	}));
 }

--- a/support/grunt/tasks/hexo.ts
+++ b/support/grunt/tasks/hexo.ts
@@ -15,7 +15,45 @@ export = function (grunt: IGrunt) {
 		const configs = [ '_config.yml' ];
 		const options = this.options<any>({
 			apiSource: join(siteDirectory, 'source/api/_apiTemplate.md'),
-			apiTarget: join(siteDirectory, 'source/api/index.md')
+			apiTarget: join(siteDirectory, 'source/api/index.md'),
+			npmTags: {
+				cli: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				core: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				has: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				i18n: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				interfaces: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				routing: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				shim: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				widgets: {
+					scope: '@dojo',
+					tag: 'beta2'
+				},
+				'widget-core': {
+					scope: '@dojo',
+					tag: 'beta2'
+				}
+			}
 		});
 		const overrideRoot = env.hexoRootOverride();
 
@@ -34,6 +72,7 @@ export = function (grunt: IGrunt) {
 			apiDirectory,
 			apiTemplate: options.apiSource,
 			apiTarget: options.apiTarget,
+			npmTags: options.npmTags,
 			configs,
 			siteDirectory
 		});

--- a/tests/unit/commands/getApiPackages.ts
+++ b/tests/unit/commands/getApiPackages.ts
@@ -1,8 +1,9 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { join } from 'path';
 import loadModule from '../../_support/loadModule';
 import { cleanupModuleMocks } from '../../_support/loadModule';
-import { DocumentedApi, default as getApiPackagesInstance } from 'support/commands/getApiPackages';
+import getApiPackagesInstance from 'support/commands/getApiPackages';
 
 let getApiPackages: typeof getApiPackagesInstance;
 
@@ -22,44 +23,81 @@ registerSuite({
 							'_ignored'
 						];
 					}
-					if (dir === 'api/cli') {
+					if (dir === join('api', 'cli')) {
 						return [
 							'v2.0.0-alpha.12',
 							'notasemver',
 							'v2.0.0-beta1.1'
 						];
 					}
-					if (dir === 'api/loader') {
+					if (dir === join('api', 'loader')) {
 						return [
 							'v2.0.0-beta.9',
 							'v2.0.0-beta1.1'
 						];
 					}
-					if (dir === 'api/empty') {
+					if (dir === join('api', 'empty')) {
 						return [];
 					}
 					throw new Error(`unknown path ${ dir }`);
 				},
 
 				lstatSync(path: string) {
-					if (path === 'api/cli'
-						|| path === 'api/loader'
-						|| path === 'api/_ignored'
-						|| path === 'api/empty') {
+					if (path === join('api', 'cli')
+						|| path === join('api', 'loader')
+						|| path === join('api', '_ignored')
+						|| path === join('api', 'empty')) {
 						return {
 							isDirectory() {
 								return true;
 							}
-						}
+						};
 					}
-					if (path === 'api/file') {
+					if (path === join('api', 'file')) {
 						return {
 							isDirectory() {
 								return false;
 							}
-						}
+						};
 					}
 					throw new Error(`unknown path ${ path }`);
+				}
+			},
+			'grunt-dojo2-extras/src/util/process': {
+				exec(command: string) {
+					const segments = command.split(/\s/);
+					const packageInfo = segments[2];
+
+					if (!packageInfo) {
+						throw new Error(`unexpected command ${ command }`);
+					}
+
+					const packageNameAndTag = packageInfo.split('/')[1];
+
+					if (!packageNameAndTag) {
+						throw new Error(`unexpected command ${ command }`);
+					}
+
+					const [ packageName, tag ] = packageNameAndTag.split('@');
+
+					if (!packageName || !tag) {
+						throw new Error(`unexpected command ${ command }`);
+					}
+
+					if (packageName === 'cli') {
+						return { stdout: '2.0.0-alpha.12' };
+					}
+
+					if (packageName === 'loader') {
+						return { stdout: '2.0.0-beta.9' };
+					}
+
+					return { stdout: '' };
+				}
+			},
+			'grunt-dojo2-extras/src/util/streams': {
+				toString(stdout: string) {
+					return Promise.resolve(stdout);
 				}
 			}
 		};
@@ -71,32 +109,67 @@ registerSuite({
 	},
 
 	test() {
-		const apis: DocumentedApi[] = getApiPackages('api');
-		assert.deepEqual(apis, [
-			{
-				format: 'html',
-				latest: 'v2.0.0-beta1.1',
-				package: 'cli',
-				versions: [
-					'v2.0.0-alpha.12',
-					'v2.0.0-beta1.1'
-				]
-			},
-			{
-				format: 'html',
-				latest: 'v2.0.0-beta1.1',
-				package: 'loader',
-				versions: [
-					'v2.0.0-beta.9',
-					'v2.0.0-beta1.1'
-				]
-			},
-			{
-				format: 'html',
-				latest: null,
-				package: 'empty',
-				versions: []
-			}
-		]);
+		return getApiPackages('api').then(apis => {
+			assert.deepEqual(apis, [
+				{
+					format: 'html',
+					latest: 'v2.0.0-beta1.1',
+					package: 'cli',
+					versions: [
+						'v2.0.0-alpha.12',
+						'v2.0.0-beta1.1'
+					]
+				},
+				{
+					format: 'html',
+					latest: 'v2.0.0-beta1.1',
+					package: 'loader',
+					versions: [
+						'v2.0.0-beta.9',
+						'v2.0.0-beta1.1'
+					]
+				},
+				{
+					format: 'html',
+					latest: null,
+					package: 'empty',
+					versions: []
+				}
+			]);
+		});
+	},
+
+	testWithNpmTags() {
+		return getApiPackages('api', {
+			cli: { tag: 'beta2', scope: '@dojo' },
+			loader: { tag: 'beta1', scope: '@dojo' }
+		}).then(apis => {
+			assert.deepEqual(apis, [
+				{
+					format: 'html',
+					latest: 'v2.0.0-alpha.12',
+					package: 'cli',
+					versions: [
+						'v2.0.0-alpha.12',
+						'v2.0.0-beta1.1'
+					]
+				},
+				{
+					format: 'html',
+					latest: 'v2.0.0-beta.9',
+					package: 'loader',
+					versions: [
+						'v2.0.0-beta.9',
+						'v2.0.0-beta1.1'
+					]
+				},
+				{
+					format: 'html',
+					latest: null,
+					package: 'empty',
+					versions: []
+				}
+			]);
+		});
 	}
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
-		"importHelpers": true,
+		"importHelpers": false,
 		"lib": [
 			"DOM",
 			"ES5",


### PR DESCRIPTION
This allows a an npm tag to be configured (and defaults it to `beta2` for the applicable packages) when generating API docs. The version corresponding to that tag is resolved and if it exists that is used as the version to link to from the index instead of the latest.

It also adds a new test case and fixes an issue with the existing test case on Windows.