### PR TITLE
Fix zero height bug in Safari

### DIFF
--- a/site/themes/dojo/source/css/_views/tutorial.styl
+++ b/site/themes/dojo/source/css/_views/tutorial.styl
@@ -3,6 +3,7 @@
 .body-tutorial {
 
 	.page-content {
+		height: 100%;
 
 		.tutorial-content {
 			position: relative;
@@ -84,7 +85,7 @@
 
 	img{
 		max-width: 100%;
-		
+
 		&.half-width {
 			width: 40%;
 			margin: 0 5%;


### PR DESCRIPTION
Fix an issue with the tutorial content having a zero height in older versions of Safari.  

There is a CSS class using calc() and in older versions of Safari, each parent node needs to have a height setting.

Fixes #148 