### PR TITLE
Disable pagination for tutorials on mobile

### DIFF
--- a/site/themes/dojo/layout/_partial/paginator.ejs
+++ b/site/themes/dojo/layout/_partial/paginator.ejs
@@ -13,5 +13,33 @@
 
 <script src="/js/tutorial-support.js"></script>
 <script>
-	tutorial.populatePaginator(document.getElementById('paginator'), <%- "'"+page.title+"'" %>);
+	function isMobile() {
+		if( navigator.userAgent.match(/Android/i)
+		|| navigator.userAgent.match(/webOS/i)
+		|| navigator.userAgent.match(/iPhone/i)
+		|| navigator.userAgent.match(/iPad/i)
+		|| navigator.userAgent.match(/iPod/i)
+		|| navigator.userAgent.match(/BlackBerry/i)
+		|| navigator.userAgent.match(/Windows Phone/i)
+		){
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+	if (isMobile()) {
+		(function() {
+			var paginator = document.querySelector('.paginator');
+			paginator && paginator.parentNode.removeChild(paginator);
+			var sections = document.querySelectorAll('section.tutorial');
+			for (var i = 0; i < sections.length; i++) {
+				var section = sections[i];
+				section.classList.remove('hidden', 'hiding');
+			}
+		})();
+	}
+	else {
+		tutorial.populatePaginator(document.getElementById('paginator'), <%- "'"+page.title+"'" %>);
+	}
 </script>


### PR DESCRIPTION
The navigation elements that enable paging through tutorials takes a large amount of screen space on some mobile devices. This PR disables the pagination on mobile device and changes to a continuous scroll layout.