### PR TITLE
switch twitter and github logos on landing page

### DIFF
--- a/site/themes/dojo/source/css/_views/home.scss
+++ b/site/themes/dojo/source/css/_views/home.scss
@@ -61,11 +61,11 @@
 					background-size: contain;
 
 					&.twitter {
-						background-image: url(/images/github.png);
+						background-image: url(/images/twitter.png);
 					}
 
 					&.github {
-						background-image: url(/images/twitter.png);
+						background-image: url(/images/github.png);
 					}
 				}
 			}


### PR DESCRIPTION
Resolves #343 

Icons for Twitter and Github are switched on the landing page. This PR corrects that.