### PR TITLE
adjust H1 styles for documentation and blogs

### DIFF
--- a/site/themes/dojo/layout/cookbook.ejs
+++ b/site/themes/dojo/layout/cookbook.ejs
@@ -4,7 +4,7 @@
 			<div class="column is-3">
 				<%- partial('_partial/cookbook-nav') %>
 			</div>
-			<div class="column is-9">
+			<div class="column is-9 article">
 				<%- page.content %>
 			</div>
 		</div>

--- a/site/themes/dojo/layout/docs.ejs
+++ b/site/themes/dojo/layout/docs.ejs
@@ -4,7 +4,7 @@
 			<div class="column is-3">
 				<%- partial('_partial/docs-nav') %>
 			</div>
-			<div class="column is-9">
+			<div class="column is-9 article">
 				<%- page.content %>
 			</div>
 		</div>

--- a/site/themes/dojo/source/css/_global.scss
+++ b/site/themes/dojo/source/css/_global.scss
@@ -39,6 +39,12 @@ body {
 
 .container.article {
 	max-width: $article-max-width;
+
+	h1 {
+		font-weight: 400;
+		line-height: 1.3em;
+		margin-bottom: 0.8em;
+	}
 }
 
 

--- a/site/themes/dojo/source/css/_views/blog.scss
+++ b/site/themes/dojo/source/css/_views/blog.scss
@@ -12,6 +12,10 @@
 	.article-title {
 		font-size: 3.8rem;
 		font-weight: 300;
+
+		@media screen and (max-width: $mobile-break) {
+			font-size: 2.4em;
+		}
 	}
 
 	.article-entry {


### PR DESCRIPTION
Resolves #351 

* Changed the styling on documentation pages (docs, tutorials, and cookbooks) to improve visual hierarchy when compared to H2
* reduced size of H1 tags on mobile form factors