### PR TITLE
Use state history in the routing tutorial

### DIFF
--- a/site/source/tutorials/1030_routing/demo/finished/biz-e-corp/src/main.ts
+++ b/site/source/tutorials/1030_routing/demo/finished/biz-e-corp/src/main.ts
@@ -1,7 +1,7 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { Registry } from '@dojo/widget-core/Registry';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
-import { StateHistory } from '@dojo/routing/history/StateHistory'
+import { StateHistory } from '@dojo/routing/history/StateHistory';
 
 import App from './widgets/App';
 

--- a/site/source/tutorials/1030_routing/demo/finished/biz-e-corp/src/main.ts
+++ b/site/source/tutorials/1030_routing/demo/finished/biz-e-corp/src/main.ts
@@ -1,6 +1,7 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { Registry } from '@dojo/widget-core/Registry';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
+import { StateHistory } from '@dojo/routing/history/StateHistory'
 
 import App from './widgets/App';
 
@@ -30,8 +31,9 @@ const routingConfig = [
 	}
 ];
 
+const history = new StateHistory();
 const registry = new Registry();
-const router = registerRouterInjector(routingConfig, registry);
+const router = registerRouterInjector(routingConfig, registry, { history });
 
 const Projector = ProjectorMixin(App);
 const projector = new Projector();

--- a/site/source/tutorials/1030_routing/index.md
+++ b/site/source/tutorials/1030_routing/index.md
@@ -40,23 +40,33 @@ Application routing paths are assembled into a hierarchy bsaed on the routing co
 
 {% instruction 'Include the required imports in the file `main.ts`.' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' lines:2,3 %}
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' lines:2-4 %}
 
 {% instruction 'Define the routing configuration.' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' lines:9-31 %}
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' lines:9-32 %}
 
 Explanations for the route configuration in the above code block are explained earlier in this step.
 
 {% instruction 'Now, register the router in a `registry`.' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' lines:33-34 %}
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' lines:34-36 %}
 
-The `registerRouterInjector` helper utility used in the code above is provided by `@dojo/routing`, and can be used to create a routing instance. The utility accepts the application's routing configuration, and a `registry` to define a `router` injector against. The utility returns the `router` instance.
+The `registerRouterInjector` helper utility used in the code above is provided by `@dojo/routing`, and can be used to create a routing instance. The utility accepts:
+
+* The application's routing configuration
+* A `registry` to define a `router` injector against
+* An object which specifies the [history manager](https://github.com/dojo/routing#history-management) to be used
+
+The utility returns the `router` instance.
+
+{% aside 'History Managers' %}
+The default history manager uses hash-based (fragment style) URLs. You can omit the third argument to `registerRouterInjector` to fallback to hash-based URLs.
+{% endaside %}
 
 {% instruction 'Initialize the routing' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' line:38-41 %}
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' line:40-43 %}
 
 {% aside 'Important!' %}
 When using a `defaultRoute` in the routing configuration, the `router` will need to be started after the projector is appended.

--- a/site/source/tutorials/1030_routing/index.md
+++ b/site/source/tutorials/1030_routing/index.md
@@ -127,7 +127,7 @@ Now, we can the swap out the widgets for the newly created `outlets`. Notice we 
 
 {% include_codefile 'demo/finished/biz-e-corp/src/widgets/App.ts' lines:50-55,59-61 %}
 
-Running the application now should display the `Banner.ts` by default, but also enable routing to the other widgets using the `/#directory` and `/#new-worker` routes.
+Running the application now should display the `Banner.ts` by default, but also enable routing to the other widgets using the `/directory` and `/new-worker` routes.
 
 Next, we will add a side menu with links for the created outlets.
 


### PR DESCRIPTION
Instead of using fragment URLs, this PR updates the tutorial + demo code to use push state URLs.

Resolves #285 