### PR TITLE
Temporarily hide testing cookbook entry

### DIFF
--- a/site/source/cookbook/testing/mocking-imports.md
+++ b/site/source/cookbook/testing/mocking-imports.md
@@ -1,5 +1,5 @@
 ---
-layout: cookbook
+layout: false
 category: testing
 title: Test and mock the imports of a widget
 overview: Learn one strategy of mocking imports in a widget


### PR DESCRIPTION
Example is out of date and not an encouraged pattern, needs to be updated to use more recent versions of the test harness

[skip ci]