### PR TITLE
Animations Tutorial: Edit the .zip link's URL

### DIFF
--- a/site/source/tutorials/008_animations/index.md
+++ b/site/source/tutorials/008_animations/index.md
@@ -430,6 +430,6 @@ In this tutorial, we learned:
 * How to control an animation
 * That zombies feel love 😂 💕
 
-You can download the completed [demo application](../assets/008_animation-finished.zip) from this tutorial.
+You can download the completed [demo application](../assets/008_animations-finished.zip) from this tutorial.
 
 {% section 'last' %}


### PR DESCRIPTION
The link to the finished version of the Web Animations tutorial results in a 404. It points to 008_animation-finished.zip but the actual filename is 008_animations-finished.zip.  Great Tutorials!