### PR TITLE
Fixes #404 - IE11 rendering

### DIFF
--- a/site/themes/dojo/source/css/_global.scss
+++ b/site/themes/dojo/source/css/_global.scss
@@ -14,7 +14,7 @@ body {
 .content-wrapper {
 	display: flex;
 	flex-direction: column;
-	flex: 1;
+	flex: 1 0 auto;
 	overflow-y: auto;
 	overflow-x: hidden;
 	margin-top: 2em;


### PR DESCRIPTION
The issue with IE11 was that flex: 1; doesn’t work properly and it was set that way on .content-wrapper. Changing this to flex: 1 0 auto; fixes the rendering issue.

See https://github.com/philipwalton/flexbugs#flexbug-6

Signed-off-by: Torrey <rice@sitepen.com>