### PR TITLE
update create app instruction

### DIFF
--- a/site/themes/dojo/layout/_partial/landingPage/upAndRunning.ejs
+++ b/site/themes/dojo/layout/_partial/landingPage/upAndRunning.ejs
@@ -17,11 +17,17 @@
 			<div id="upAndRunning-typing-2" class="codeline">
 				<span class="line-number">2</span>
 				<span class="typed-text">
-					dojo create --name hello-world
+					npm i @dojo/cli-create-app
 				</span>
 			</div>
 			<div id="upAndRunning-typing-3" class="codeline">
 				<span class="line-number">3</span>
+				<span class="typed-text">
+					dojo create app --name hello-world
+				</span>
+			</div>
+			<div id="upAndRunning-typing-4" class="codeline">
+				<span class="line-number">4</span>
 				<span class="typed-text">
 					<strong>
 						Go!

--- a/site/themes/dojo/layout/_partial/landingPage/upAndRunning.ejs
+++ b/site/themes/dojo/layout/_partial/landingPage/upAndRunning.ejs
@@ -11,23 +11,17 @@
 			<div id="upAndRunning-typing-1" class="codeline">
 				<span class="line-number">1</span>
 				<span class="typed-text">
-					npm i @dojo/cli -g
+					npm i @dojo/cli @dojo/cli-create-app -g
 				</span>
 			</div>
 			<div id="upAndRunning-typing-2" class="codeline">
 				<span class="line-number">2</span>
 				<span class="typed-text">
-					npm i @dojo/cli-create-app
+					dojo create app --name hello-world
 				</span>
 			</div>
 			<div id="upAndRunning-typing-3" class="codeline">
 				<span class="line-number">3</span>
-				<span class="typed-text">
-					dojo create app --name hello-world
-				</span>
-			</div>
-			<div id="upAndRunning-typing-4" class="codeline">
-				<span class="line-number">4</span>
 				<span class="typed-text">
 					<strong>
 						Go!


### PR DESCRIPTION
the getting started doc on the front page doesn't work. I imagine this changed between beta's and rc. It should be current as it reflects poorly if the get going quickly fails. 