### PR TITLE
Fix get going quickly

### DIFF
--- a/site/themes/dojo/layout/_partial/landingPage/upAndRunning.ejs
+++ b/site/themes/dojo/layout/_partial/landingPage/upAndRunning.ejs
@@ -116,7 +116,7 @@
 		function updateTyping1Animations(percentCompletion) {
 			var typing = {
 				x1: 0, x2: 0.15,
-				y1: 0, y2: 220
+				y1: 0, y2: 365
 			};
 			var fadeIn = {
 				x1: 0.15, x2: 0.2,
@@ -139,7 +139,7 @@
 			};
 			var typing = {
 				x1: 0.25, x2: 0.4,
-				y1: 0, y2: 310
+				y1: 0, y2: 350
 			};
 			var fadeIn = {
 				x1: 0.4, x2: 0.45,

--- a/site/themes/dojo/source/css/_partials/landingPage/upAndRunning.scss
+++ b/site/themes/dojo/source/css/_partials/landingPage/upAndRunning.scss
@@ -24,7 +24,7 @@ section.up-and-running {
 	}
 
 	.commands {
-		padding: 10vh 5vw;
+		padding: 10vh 2vw;
 
 		@media screen and (max-width : $mobile-break) {
 			padding: 3vh 5vw;

--- a/site/themes/dojo/source/css/_partials/landingPage/upAndRunning.scss
+++ b/site/themes/dojo/source/css/_partials/landingPage/upAndRunning.scss
@@ -9,9 +9,13 @@ section.up-and-running {
 		justify-content: space-evenly;
 	}
 
+	.commands {
+		width: 52%;
+	}
+	.results {
+		width: 46%;
+	}
 	.commands, .results {
-		width: 49%;
-
 		@media screen and (max-width : $mobile-break) {
 			width: initial;
 		}


### PR DESCRIPTION
Adds to https://github.com/dojo/dojo.io/pull/416 to give the animation enough space to show all the text and update the widths so the image doesn't overlap the text at smaller screen sizes.