### PR TITLE
Updates Container & Injector Tutorial based on the new API

### DIFF
--- a/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/src/ApplicationContext.ts
+++ b/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/src/ApplicationContext.ts
@@ -1,18 +1,19 @@
 import { deepAssign } from '@dojo/core/lang';
-import { Injector } from '@dojo/widget-core/Injector';
 
 import { WorkerProperties } from './widgets/Worker';
 import { WorkerFormData } from './widgets/WorkerForm';
 
-export default class ApplicationContext extends Injector {
+export default class ApplicationContext {
 
 	private _workerData: WorkerProperties[];
 
 	private _formData: Partial<WorkerFormData> = {};
 
-	constructor(workerData: WorkerProperties[] = []) {
-		super({});
+	private _invalidator: () => void;
+
+	constructor(invalidator: () => void, workerData: WorkerProperties[] = []) {
 		this._workerData = workerData;
+		this._invalidator = invalidator;
 	}
 
 	get workerData(): WorkerProperties[] {
@@ -25,16 +26,12 @@ export default class ApplicationContext extends Injector {
 
 	public formInput(input: Partial<WorkerFormData>): void {
 		this._formData = deepAssign({}, this._formData, input);
-		this.emit({ type: 'invalidate' });
+		this._invalidator();
 	}
 
 	public submitForm(): void {
 		this._workerData = [ ...this._workerData, this._formData ];
 		this._formData = {};
-		this.emit({ type: 'invalidate' });
-	}
-
-	get(): ApplicationContext {
-		return this;
+		this._invalidator();
 	}
 }

--- a/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/src/main.ts
+++ b/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/src/main.ts
@@ -6,29 +6,30 @@ import App from './widgets/App';
 
 const root = document.querySelector('my-app') || undefined;
 
-const applicationContext = new ApplicationContext([
-	{
-		firstName: 'Tim',
-		lastName: 'Jones',
-		email: 'tim.jones@bizecorp.org',
-		tasks: [
-			'6267 - Untangle paperclips',
-			'4384 - Shred documents',
-			'9663 - Digitize 1985 archive'
-		]
-	},
-	{
-		firstName: 'Alicia',
-		lastName: 'Fitzgerald'
-	},
-	{
-		firstName: 'Hans',
-		lastName: 'Mueller'
-	}
-]);
-
 const registry = new Registry();
-registry.defineInjector('app-state', applicationContext);
+registry.defineInjector('app-state', (invalidator) => {
+	const applicationContext = new ApplicationContext(invalidator, [
+		{
+			firstName: 'Tim',
+			lastName: 'Jones',
+			email: 'tim.jones@bizecorp.org',
+			tasks: [
+				'6267 - Untangle paperclips',
+				'4384 - Shred documents',
+				'9663 - Digitize 1985 archive'
+			]
+		},
+		{
+			firstName: 'Alicia',
+			lastName: 'Fitzgerald'
+		},
+		{
+			firstName: 'Hans',
+			lastName: 'Mueller'
+		}
+	]);
+	return () => applicationContext;
+});
 
 const Projector = ProjectorMixin(App);
 const projector = new Projector();

--- a/site/source/tutorials/1010_containers_and_injecting_state/index.md
+++ b/site/source/tutorials/1010_containers_and_injecting_state/index.md
@@ -36,7 +36,7 @@ Most of this widget is dedicated to holding and managing the `WorkerData` in the
 {% include_codefile 'demo/finished/biz-e-corp/src/ApplicationContext.ts' %}
 
 {% aside 'Invalidations' %}
-Dojo 2 Widgets can invoke `invalidate()` directly, however injector factories receive an `invalidator` that can be called to ensure that all connected widgets are invalidated
+Dojo 2 Widgets can invoke `invalidate()` directly, however, injector factories receive an `invalidator` that can be called to ensure that all connected widgets are invalidated
 {% endaside %}
 
 The code begins by importing some modules, including the `WorkerProperties` and `WorkerFormData` interfaces defined in the `Worker` and `WorkerForm` modules. These two interfaces define the shape of state that the `ApplicationContext` manages.
@@ -100,7 +100,7 @@ We need to pass the `registry` to the `projector` via the `setProperties` method
 
 {% include_codefile 'demo/finished/biz-e-corp/src/main.ts' line:36 %}
 
-Now that the `ApplicationContext` injector factory is defined and the `registry` has been set on the `projector`, it is time to create the components that will use it. In the next section, we will create a non-visual widget called a `Container` that will allow state to be injected into the `WorkerForm` and `WorkerContainer` widgets.
+Now that the `ApplicationContext` injector factory is defined, and the `registry` gets set on the `projector`, it is time to create the components that will use it. In the next section, we will create a non-visual widget called a `Container` that will allow injecting state into the `WorkerForm` and `WorkerContainer` widgets.
 
 {% section %}
 


### PR DESCRIPTION
Updates for the container & injector tutorial that reflects the changes to the API from widget-core.

Shouldn't be merged until the next release set that includes the changes

*Note:* Still requires dependency updates and changes to demo source code in tutorial 1015 (That uses the ApplicationContext)