### PR TITLE
touch db.json before trying to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,13 @@ jobs:
     env:
       - TUTORIAL=N/A
     script:
+      - touch site/db.json
       - grunt test
       - grunt ci
 deploy:
   provider: script
-  script: grunt publish
+  script:
+    - grunt publish
   skip_cleanup: true
   on:
     branch: master


### PR DESCRIPTION
This should prevent the travis build from failing by ensuring that a db.json file exists.