### PR TITLE
443 code highlights and descriptions

### DIFF
--- a/site/scripts/codefile.js
+++ b/site/scripts/codefile.js
@@ -3,7 +3,7 @@
 // File path must be a child .md file.
 
 /*
-	Usage: {% include_codefile path/to/file/relative/filename.ts [lines:1-4,7]|[line:4] [lang:ts] %}
+	Usage: {% include_codefile path/to/file/relative/filename.ts [lines:1-4,7]|[line:4] [highlight:1-2,7] [lang:ts] %}
 */
 
 var fs = require("hexo-fs");
@@ -20,6 +20,9 @@ hexo.extend.tag.register(
 		var filename = args[0];
 		var lang = false;
 		var lines = false;
+		var highlighted = false;
+		var highlightedLines = false;
+		var desc = "";
 		var content = "";
 
 		_.forEach(args.slice(1), function(arg) {
@@ -29,6 +32,15 @@ hexo.extend.tag.register(
 			if (_.startsWith(arg, "line")) {
 				lines = arg.replace(/([a-zA-Z]+?)(s\b|\b):/gm, "");
 				lines = cf.parseLinesRange(lines);
+			}
+			if(_.startsWith(arg, "highlight:")) {
+				highlighted = arg.replace("highlight:", "");
+				highlighted = cf.parseLinesRange(highlighted, true);
+			}
+
+			if(_.startsWith(arg, "desc:")) {
+				desc = arg.replace(/(^desc:\'?)|(\'$)/gm, "");
+				desc = `<div class="prism-code-desc">${desc}</div>`;
 			}
 		});
 
@@ -42,8 +54,14 @@ hexo.extend.tag.register(
 			content = rawContent;
 		}
 
-		var highlighted = Prism.highlight(cf.normalizeWhitespace(content), Prism.languages[lang]);
-		return `<pre class="language-${lang}"><code class="language-${lang}">${highlighted}</code></pre>`;
+		var prismHtml = Prism.highlight(cf.normalizeWhitespace(content), Prism.languages[lang]);
+
+		if(highlighted) {
+			highlightedLines = cf.adjustHighlightedLineNumbers(highlighted, lines);
+			prismHtml = cf.highlightHtml(prismHtml, highlightedLines);
+		}
+
+		return `<pre class="language-${lang}"><code class="language-${lang}">${prismHtml}</code>${desc}</pre>`;
 	},
 	{ async: true }
 );
@@ -63,7 +81,7 @@ var cf = {
 
 		return str.replace(re, "");
 	},
-	parseLinesRange(str) {
+	parseLinesRange(str, returnMap) {
 		var lines = {};
 		var lineGroups;
 		if (str.indexOf(",") !== -1) {
@@ -84,9 +102,14 @@ var cf = {
 			}
 		});
 
-		var result = Object.keys(lines).sort(function(l, r) {
-			return parseInt(l, 10) - parseInt(r, 10);
-		});
+		if(returnMap) {
+			var result = lines;
+		} else {
+			var result = Object.keys(lines).sort(function (l, r) {
+				return parseInt(l, 10) - parseInt(r, 10);
+			});
+		}
+
 		return result;
 	},
 
@@ -115,5 +138,35 @@ var cf = {
 		}
 
 		return fragment;
+	},
+
+	adjustHighlightedLineNumbers(highlightedLines, lines) {
+		var linesToHighlight = {};
+		if(lines) {
+			for (var i = 0; i < lines.length; i++) {
+				if (highlightedLines[lines[i]]) {
+					linesToHighlight[i + 1] = true;
+				}
+			}
+		} else {
+			_.forEach(highlightedLines, function(line, key) {
+				linesToHighlight[parseInt(key, 10) + 1] = true;
+			})
+		}
+		return linesToHighlight;
+	},
+
+	highlightHtml(html, lines) {
+		var lineNumber = 1;
+		var highlighted = [];
+
+		_.forEach(html.split("\n"), function(line) {
+			if(lines[lineNumber++]) {
+				highlighted.push(`<span class="line-highlight">${line}</span>`);
+			} else {
+				highlighted.push(line);
+			}
+		});
+		return highlighted.join("\n");
 	}
 };

--- a/site/scripts/codefile.js
+++ b/site/scripts/codefile.js
@@ -3,7 +3,7 @@
 // File path must be a child .md file.
 
 /*
-	Usage: {% include_codefile path/to/file/relative/filename.ts [lines:1-4,7]|[line:4] [highlight:1-2,7] [lang:ts] %}
+	Usage: {% include_codefile path/to/file/relative/filename.ts [lines:1-4,7]|[line:4] [highlight:1-2,7] [desc:'text appears at bottom of block'] [lang:ts] %}
 */
 
 var fs = require("hexo-fs");

--- a/site/source/tutorials/007_theming/index.md
+++ b/site/source/tutorials/007_theming/index.md
@@ -39,7 +39,7 @@ In order to theme our widgets, we must ensure that they each apply the `ThemedMi
 
 {% instruction 'Replace the contents of `Banner.ts` with the following' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Banner.ts' lines:1-13 %}
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/Banner.ts' lines:1-13 highlight:3-9 desc:'File: src/widgets/Banner.ts' lang:typescript %}
 
 {% aside 'Reminder' %}
 If you cannot see the application, remember to run `dojo build -m dev -w memory -s` to build the application and start the development server.
@@ -57,7 +57,7 @@ Notice that this file and other `css` files now have a `.m.css` file extension. 
 
 We will create an empty `root` class for now as our base theme does not require any styles to be added to the `Banner` widget.
 
-{% include_codefile 'demo/finished/biz-e-corp/src/styles/banner.m.css' lang:css %}
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/banner.m.css' lang:css desc:'File: src/styles/banner.m.css' %}
 
 {% instruction 'Now, let\'s look at changing the `WorkerForm` widget' %}
 
@@ -67,48 +67,22 @@ Fixed classes apply styles that cannot be overridden by a theme, using a suffix 
 
 `WorkerForm` already uses the `ThemedMixin` and has a `workerForm` class on its root node. Let's change the workerForm class to a `root` class, and while we are there, we will create a `rootFixed` class too, and apply it to the root node. Classes that are not passed to `theme` cannot be changed or overridden via a theme, ensuring that structured or nested styles are not lost when a theme is used.
 
-{% include_codefile 'demo/finished/biz-e-corp/src/widgets/WorkerForm.ts' lines:47-50 %}
+{% include_codefile 'demo/finished/biz-e-corp/src/widgets/WorkerForm.ts' lines:47-50 highlight:48 desc:'File: src/widgets/WorkerForms.ts' lang:typescript %}
 
 Replace all of the selectors containing `.workerForm` with the following rules in `workerForm.m.css`.
 
-{% include_codefile 'demo/finished/biz-e-corp/src/styles/workerForm.m.css' lines:1-17 lang:css %}
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/workerForm.m.css' lines:1-17 highlight:1,5,9-10,15 lang:css desc:'File: src/styles/workerForm.m.css' %}
 
 If you open the application in a browser its appearance and behavior should be unchanged.
 
-{% instruction 'Now update `worker.m.css` and `workerContainer.m.css` to use `.root` and `.rootFixed` and then update the associated widgets to use the new selectors.' %}
+{% instruction 'Now update `worker.m.css` and `workerContainer.m.css` to use `.root` and `.rootFixed`...' %}
 
-```css
-/* workerContainer.m.css */
-.rootFixed {
-	display: flex;
-	flex-flow: row wrap;
-	justify-content: center;
-	align-items: stretch;
-	margin: 0 auto;
-	width: 100%;
-}
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/workerContainer.m.css' highlight:1,10-12 desc:'File: src/styles/workerContainer.m.css' %}
 
-.root {
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/worker.m.css' lines:1-13 highlight:1,9 desc:'File: src/styles/worker.m.css. (All rules were originally in the .worker selector.)' %}
 
-}
+{% instruction '...and then update the associated widgets to use the new selectors.' %}
 
-/* worker.m.css */
-
-/* all rules were originally in the .worker selector */
-.root {
-	margin: 0 10px 40px;
-	max-width: 350px;
-	min-width: 250px;
-	flex: 1 1 calc(33% - 20px);
-	position: relative;
-}
-
-.rootFixed {
-	/* flip transform styles */
-	perspective: 1000px;
-	transform-style: preserve-3d;
-}
-```
 ```typescript
 // WorkerContainer.ts
 // ...
@@ -165,19 +139,9 @@ Let's start by creating a red `Worker` and observe our theme being applied corre
 }
 ```
 
-So for `worker.m.css`, you need to add the import for the `worker.m.css` and the theme itself to the exported object using the key `biz-e-corp/worker`.
+So for `theme.ts`, you need to add the import for the `worker.m.css` and the theme itself to the exported object using the key `biz-e-corp/worker`.
 
-``` typescript
-import * as textInput from './@dojo/widgets/text-input/text-input.m.css';
-import * as button from './@dojo/widgets/button/button.m.css';
-import * as worker from './worker.m.css';
-
-export default {
-	'@dojo/widgets/button': button,
-	'@dojo/widgets/text-input': textInput,
-	'biz-e-corp/worker': worker
-};
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/theme.ts' lines:3,6-9,11,14-16 highlight:3,11 desc:'File: src/themes/dojo/theme.ts' lang:typescript %}
 
 To apply a theme to a widget, simply pass the `theme` as a property to widgets to have the `ThemedMixin` applied. To ensure that the entire application applies the `theme` it needs to be passed to all the themed widgets in our application. This can become problematic when an application uses a mixture of themed and non-themed widgets, or uses a widget from a third party, meaning that there is no guarantee that the `theme` will be propagated as required.
 
@@ -189,7 +153,7 @@ However an application can automatically inject a `theme` from the `registry` to
 
 {% instruction 'Update our `main.ts` file to import our theme and create a `themeInjector`.' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' %}
+{% include_codefile 'demo/finished/biz-e-corp/src/main.ts' highlight:3-5,8-9,14-16 desc:'File: src/main.ts' lang:typescript %}
 
 Open the application in your web browser and see that the `Worker` backgrounds are now `red`.
 
@@ -198,14 +162,14 @@ Open the application in your web browser and see that the `Worker` backgrounds a
 The [Dojo 2 build system](../006_deploying_to_production/) supports new CSS features such as `css-custom-properties` by using PostCSS to process our `.m.css` files. We can use these new CSS features to add variables to `worker.m.css` and complete its theme.
 Let's create `themes/dojo/variables.css` (notice that this file does not have a `.m.css` extension as it is not a `css-module` file).
 
-{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/variables.css' lang:css %}
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/variables.css' lang:css desc:'File: src/themes/dojo/variables.css' %}
 
 In the above code you can see that we have created a number of CSS Custom Properties to be used within our theme and wrapped them in a `:root` selector which makes them available on the global scope within our `css-modules`.
 To use them, we can `@import` the `variables.css` file and use the `var` keyword to assign a `css-custom-property` to a css rule.
 
 Now we will use these variables in our themes `worker.m.css` to create our fully themed `Worker`.
 
-{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/worker.m.css' lang:css %}
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/worker.m.css' lang:css highlight:1,7,12,16,20,34,39,45,46,50,51,66,67,77 desc:'File: src/themes/dojo/worker.m.css' %}
 
 {% section %}
 
@@ -215,22 +179,15 @@ Thus far in this tutorial, we have themed our custom `Worker` widget, but we hav
 
 {% instruction 'Let\'s create `workerForm.m.css`' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/workerForm.m.css' lang:css %}
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/workerForm.m.css' lang:css desc:'File: src/themes/dojo/workerForm.m.css' %}
 
 {% instruction 'And include it in `theme.ts`' %}
 
-``` typescript
-import * as worker from './worker.m.css';
-import * as workerForm from './workerForm.m.css';
-export default {
-	'biz-e-corp/worker': worker,
-	'biz-e-corp/workerForm': workerForm,
-};
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/theme.ts' lines:3,5,8,9,11,13,16 highlight:5,13 desc:'File: src/themes/dojo/theme.ts' lang:typescript %}
 
 This should be familiar from theming the `Worker` in the previous section. To theme the Dojo 2 `TextInput` within our `WorkerForm`, we need to add to the skeleton `text-input.m.css` theme created by `@dojo/cli-create-theme`, this is already exported from `theme.ts`.
 
-{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/@dojo/widgets/text-input/text-input.m.css' lang:css %}
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/@dojo/widgets/text-input/text-input.m.css' lang:css highlight:6 desc:'File: src/themes/dojo/@dojo/widgets/text-input/text-input.m.css' %}
 
 Notice the styling rule for the `.root` selector? Here we are introducing another powerful part of the Dojo 2 theming system, `composes`. Composes originates in the [`css-module` specification](https://github.com/css-modules/css-modules#composition), allowing you to apply styles from one class selector to another. Here we are specifying that the `root` of a `TextInput` (the label text in this case), should appear the same as the `nameLabel` class in our `WidgetForm`. This approach can be very useful when creating multiple themes from a `baseTheme` and avoids repetitive redefinition of style rules.
 
@@ -238,21 +195,7 @@ In your web browser you will see the `TextInput` widgets at the top of the form 
 
 {% instruction 'Add the following theme styles to the `button.m.css` theme resource' %}
 
-``` css
-@import './../../../variables';
-
-.root {
-	height: 38px;
-	border: 1px solid var(--input-border);
-	background: var(--card);
-	color: var(--accent);
-	font-size: 16px;
-	font-weight: bold;
-	padding: 8px;
-	min-width: 150px;
-	vertical-align: bottom;
-}
-```
+{% include_codefile 'demo/finished/biz-e-corp/src/themes/dojo/@dojo/widgets/button/button.m.css' lang:css desc:'File: src/themes/dojo/@dojo/widgets/button/button.m.css' %}
 
 {% section %}
 

--- a/site/source/tutorials/007_theming/index.md
+++ b/site/source/tutorials/007_theming/index.md
@@ -77,9 +77,9 @@ If you open the application in a browser its appearance and behavior should be u
 
 {% instruction 'Now update `worker.m.css` and `workerContainer.m.css` to use `.root` and `.rootFixed`...' %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/styles/workerContainer.m.css' highlight:1,10-12 desc:'File: src/styles/workerContainer.m.css' %}
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/workerContainer.m.css' highlight:1,10-12 desc:'File: src/styles/workerContainer.m.css' lang:css %}
 
-{% include_codefile 'demo/finished/biz-e-corp/src/styles/worker.m.css' lines:1-13 highlight:1,9 desc:'File: src/styles/worker.m.css. (All rules were originally in the .worker selector.)' %}
+{% include_codefile 'demo/finished/biz-e-corp/src/styles/worker.m.css' lines:1-13 highlight:1,9 desc:'File: src/styles/worker.m.css. (All rules were originally in the .worker selector.)' lang:css %}
 
 {% instruction '...and then update the associated widgets to use the new selectors.' %}
 

--- a/site/themes/dojo/source/css/_util/highlight.scss
+++ b/site/themes/dojo/source/css/_util/highlight.scss
@@ -13,6 +13,27 @@ body pre[class *= "language-"],
 	@extend .uk-margin;
 }
 
+pre .prism-code-desc {
+	font-family: sans-serif;
+	font-size: 90%;
+	white-space: normal;
+	background-color: #dddddd !important; /* same bg as prism border, not sure how to get this value in here in case of theme change */
+	margin: $padding-small-padding (0 - $padding-small-padding) (0 - $padding-small-padding) (0 - $padding-small-padding);
+	padding: 5px;
+}
+
+pre[class *= "language-"] .line-highlight {
+	background: transparent;
+	margin-left: -0.75em;
+
+	&:before {
+		font-weight: bolder;
+		content: "\2022";
+		color: #00d096;
+		margin-right: 0.2em;
+	}
+}
+
 pre code {
 	background: transparent;
 }


### PR DESCRIPTION
Updated `include_codefile` to accept two more arguments:

`highlight` - allows you to highlight lines from the original source file. Same usage as `lines`. Note: the line numbers are the same as the lines in the source file, not just what is imported. So if `lines:5-10` and you want to highlight the first line imported it is still `highlight:5`, not `highlight:1`. This should make sense because you will be comparing lines from the original file.

`desc` - allows you to add a description to the bottom of the code block. My intention for adding it was to allow you to put the file name on the block for quick reference. The theming tutorial has been updated accordingly.