### PR TITLE
Added missing @dojo/widgets dependency

### DIFF
--- a/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/package.json
+++ b/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@dojo/framework": "^3.0.0",
     "@dojo/core": "^2.0.0",
+    "@dojo/widgets": "^3.0.0",
     "tslib": "~1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
npm install fails due to missing dependency to "@dojo/widgets": "^3.0.0" for finished tutorial demo.