### PR TITLE
Parse pragma to include and remove sections from READMEs in the docs

### DIFF
--- a/docviewer/src/render_doc.ts
+++ b/docviewer/src/render_doc.ts
@@ -51,6 +51,13 @@ export default async function renderDoc(
 			text = await docFetch(repo + '/' + version + '/' + file);
 		}
 
+		if (file.indexOf('widget-core') > -1) {
+			text = removeReadMeSections(text);
+			text = text.replace(/<!--DOCSONLY/g, '');
+			text = text.replace(/DOCSONLY-->/g, '');
+			console.log(text);
+		}
+
 		const html = renderMarkdown(text, { ref, docs });
 		page = h('div', { innerHTML: html });
 
@@ -146,6 +153,17 @@ function extractToc(elem: Element) {
 			return child;
 		}
 	}
+}
+
+function removeReadMeSections(content: string) {
+	let startIndex = content.indexOf('<!--READMEONLY-->');
+	let endIndex = null;
+	while (startIndex > -1) {
+		endIndex = content.indexOf('<!--READMEONLY-->', startIndex + 1);
+		content = content.replace(content.slice(startIndex, endIndex + 17), '');
+		startIndex = content.indexOf('<!--READMEONLY-->');
+	}
+	return content;
 }
 
 /**

--- a/docviewer/src/render_doc.ts
+++ b/docviewer/src/render_doc.ts
@@ -53,8 +53,8 @@ export default async function renderDoc(
 
 		if (file.indexOf('widget-core') > -1) {
 			text = removeReadMeSections(text);
-			text = text.replace(/<!--DOCSONLY/g, '');
-			text = text.replace(/DOCSONLY-->/g, '');
+			text = text.replace(/<!--DOCSONLY--/g, '');
+			text = text.replace(/--DOCSONLY-->/g, '');
 			console.log(text);
 		}
 

--- a/docviewer/src/render_doc.ts
+++ b/docviewer/src/render_doc.ts
@@ -51,12 +51,9 @@ export default async function renderDoc(
 			text = await docFetch(repo + '/' + version + '/' + file);
 		}
 
-		if (file.indexOf('widget-core') > -1) {
-			text = removeReadMeSections(text);
-			text = text.replace(/<!--DOCSONLY--/g, '');
-			text = text.replace(/--DOCSONLY-->/g, '');
-			console.log(text);
-		}
+		text = removeReadMeSections(text);
+		text = text.replace(/<!--DOCSONLY--/g, '');
+		text = text.replace(/--DOCSONLY-->/g, '');
 
 		const html = renderMarkdown(text, { ref, docs });
 		page = h('div', { innerHTML: html });


### PR DESCRIPTION
Implements rudimentary parsing of two pragmas:

* `<!--READMEONLY-->`
  * a pragma used a the beginning and end of content that should be excluded when rendering the content for the docs site
* `<!--DOCSONLY--` & `--DOCSONLY-->`
  * a pragma that wraps content that should be excluded from the README but included in the docs site

```md
<!--READMEONLY-->
Section will render on the readme but not on the docs
<!--READMEONLY-->
<!--DOCSONLY--Section will render on dojo.io docs but not on the README--DOCSONLY-->
```

Resolves: https://github.com/dojo/dojo.io/issues/467