### PR TITLE
Dojo 4 blog

### DIFF
--- a/site/source/_drafts/dojo-4-release.md
+++ b/site/source/_drafts/dojo-4-release.md
@@ -1,33 +1,62 @@
 ---
-title: Dojo Version 4.0
-authorId: paul
+title: Announcing Version 4 of Dojo
+date: 2018-10-04 08:00:00
+authorId: devpaul
+featured_image: featured.jpg
 ---
+{% asset_img featured.jpg feature-full %}
 
 ## Being a Better Dojo
 
-We believe that developer ergonomics and strong community support are fundamental reasons for choosing any framework. If you can't be comfortable and efficient working with a system why choose it in the first place? It's what leads us to engage with our community and constantly look ahead to a better, brighter Dojo.
+Developer ergonomics and strong community support are fundamental reasons for choosing any framework. If you cannot be comfortable and efficient working with a system why choose it in the first place? It's what leads us to engage with our community and constantly look ahead to a better, brighter Dojo.
 
-Two of the most considerable undertakings this release will allow the Dojo framework to focus on delivering a consistent and positive development experience. First, the underlying [Virtual DOM Engine][vdom PR] has been completely rewritten to allow vdom nodes and widgets to both be rendered as first-class citizens.
+Two of the most considerable undertakings in this release focus on delivering a consistent and positive development experience. First, the underlying [Virtual DOM Engine][vdom PR] was rewritten to allow vdom nodes and widgets to get rendered as first-class citizens.
 
- This has opened up the opportunity to make a number of improvements, like replacing the `ProjectorMixin` with an easier to use `renderer`. The `ProjectorMixin` was always one of the more confusing aspects that was immediately felt by new developers. We believe the `renderer` is more direct and consistent with how the vdom uses widgets throughout Dojo.
+The new Virtual DOM system has opened up the opportunity to make many improvements, like replacing the `ProjectorMixin` with an easier to use `renderer` API. The `ProjectorMixin` was one of the more confusing aspects for developers new to Dojo. `renderer` is more direct and consistent with how the vdom uses widgets throughout Dojo.
 
-Next, we have consolidated and removed a number of modules in the Dojo framework that have been kept around to provide tooling or legacy support. Modules like `List`, `DateObject`, `Task`, and `request` were tools brought over from the old Dojo Toolkit that had proved to be useful in the past. But, the more we've used Dojo with TypeScript and modern concepts, the less we find a need for these tools. So we made the decision to say goodbye to a lot of old, familiar friends to better focus on creating the best possible virtual DOM framework.
+Next, we have consolidated and removed many modules in the Dojo framework that were kept around to provide tooling or legacy support. Modules like `List`, `DateObject`, `Task`, and `request` were tools brought over from the old Dojo Toolkit that had proved useful in the past. However, the more we've used Dojo with TypeScript and modern concepts, the less we find a need for these tools. So we decided to say goodbye to a lot of old, familiar friends to better focus on creating the best possible virtual DOM framework.
 
-Dojo 4 adds dozens of other improvements that make it easier and more expressive. 
+Dojo Version 4 adds dozens of other improvements that make it easier and more expressive. 
 
-* better ways of working with [`Outlet`s][Outlet PR]
-* a new [`StoreProvider` widget][StoreProvider PR] making store data easier to access in widgets
-* more descriptive error and warning messages
+Within `@dojo/framework`, we've made many improvements:
+
+* TypeScript forwards compatibility from 2.7 to 3.0.
+* [Ground up rewrite of the VDOM engine][vdom PR].
+* Support for accessing meta information for nodes passed as children.
+* Return `v()` nodes directly from new vdom `renderer`.
+* Fix support for adding classes to SVG nodes.
+* Better composition of v and w nodes, using `v()` and `w()`.
+* Support dynamically imported widgets directly in `w()`.
+* `onAttach` callback for the `dom()` pragma.
+* New `watch` decorator to invalidate when a widget property is set.
+* Improved route matching algorithm.
+* [More flexible `Outlet`][Outlet PR], using a render prop.
+* `ActiveLink` widget that applies classes when considered active.
+* Local storage dojo/stores middleware.
+* New [`StoreProvider`][StoreProvider PR] for injecting application state.
+
+Numerous changes also improve the Dojo CLI:
+
+* Automatic code splitting by top level routes.
+* Development server now supports HTTPS.
+* Dojo configuration support in the package.json.
+* Proxy support with development server.
+* Updated templates from cli-create-app, optionally with TSX.
+* History API fallback for routing.
+* Automatic parsing, hashing and bundling of resources from index.html.
+* Include assets from catch all `assets` directory.
+* Externals support with build app with dojo configuration.
+* New application analyzer, with support for multiple bundles.
 
 You can read more about all of the new features in detail in the [Dojo 4 Migration Guide][Migration Guide].
 
 ## Migration
 
-The [`@dojo/cli-upgrade-app`][cli-upgrade] tool has been updated to allow for a smooth transition between Dojo 3 and Dojo 4. Simply upgrade Dojo's cli and widget packages to 4.0 and run `npm install @dojo/cli-upgrade-app@4 --no-save` and run `dojo upgrade app`. For more information please see the [migration guide][Migration Guide].
+The [`@dojo/cli-upgrade-app`][cli-upgrade] tool was updated to allow for a smooth transition between Dojo 3 and Dojo 4. Simply upgrade Dojo's cli and widget packages to 4.0 and run `npm install @dojo/cli-upgrade-app@4 --no-save` and run `dojo upgrade app`. For more information, please see the [migration guide][Migration Guide].
 
 ## Support
 
-Love what we're doing or having a problem? We ❤️ our community. Reach out to us on [Discord], check out our [roadmap] and see where Dojo is headed, and try out the new Dojo on [CodeSandbox]. Hope to see you soon!
+Love what we're doing or having a problem? We ❤️ our community. Reach out to us on [Discord], check out our [roadmap] and see where Dojo is headed, and try out the new Dojo on [CodeSandbox]. We look forward to your feedback!
 
 [vdom PR]: https://github.com/dojo/framework/issues/54
 [StoreProvider PR]: https://github.com/dojo/framework/issues/76

--- a/site/source/_drafts/dojo-4-release.md
+++ b/site/source/_drafts/dojo-4-release.md
@@ -1,0 +1,37 @@
+---
+title: Dojo Version 4.0
+authorId: paul
+---
+ “Developer ergonomics improvements and automatic build time optimisations and code splitting”
+
+## Being a Better Dojo
+
+We believe that developer ergonomics and strong community suport are fundamental reasons for choosing any framework. If you can't be comfortable and efficient working with a system why choose it in the first place? It's what leads us to engage with our community and constantly look ahead to a better, brighter Dojo.
+
+Two of the most considerable undertakings this release will allow the Dojo framework to focus on delivering a consistent and positive development experience. First, the underlying [Virtual DOM Engine](https://github.com/dojo/framework/issues/54) has been completely rewitten to allow vdom nodes and widgets to both be rendered as first-class citizens. This has opened up the opportunity to make a number of improvements like replacing the `ProjectorMixin` with an easier to use `renderer`. The `ProjectorMixin` was always one of the more confusing aspects that was immediately felt by new developers. We believe the `renderer` is more direct and consistent with how the vdom uses widgets throughout Dojo.
+
+Next, we have consolidated and removed a number of modules in Dojo framework that have been kept around to provide tooling or legacy support. Modules like `List`, `DateObject`, `Task`, and `request` were tools brought over from the old Dojo Toolkit that had proved to be useful in the past. But, the more we've used Dojo with TypeScript and modern concepts, the less we find a need for these tools. So we made the decision to say goodbye to a lot of old, familiar friends to better focus on creating the best possible virtual DOM framework.
+
+been a complete rewrite of the underlying [Virtual DOM Engine](https://github.com/dojo/framework/issues/54) and a pruning of 
+
+* Goodbye ProjectorMixin
+* Consilidating dojo/framework
+    * A number of modules have been removed that provided legacy support to es5 browsers.
+    * Of note: dojo/core/request : use fetch polyfill; async interfaces Task; utilities and collections: List, DateObject, Observable
+* Outlets are now Widgets
+    * removed onEnter and onExit to make routes static. Will help w/ automatic code-splitting to improve performance and time-to-interaction
+* Updates to testing (unit, functional builds)
+* StoreProvider widget: https://github.com/dojo/framework/issues/76
+* @watch() for internal properties https://github.com/dojo/framework/issues/74
+* improved and added error & warning messages
+
+## Migration
+
+* brief instructions `npm install @dojo/cli-upgrade-app --no-save` and run `dojo upgrade app`
+* Update cli commands and if you're using `@dojo/widgets` or `@dojo/interop` upgrade those to 4.0
+* See the [migration guide]() // TODO LINK
+
+## Support
+
+* [Discord](https://discord.gg/M7yRngE)
+* Checkout our [roadmap](https://dojo.io/community/)

--- a/site/source/_drafts/dojo-4-release.md
+++ b/site/source/_drafts/dojo-4-release.md
@@ -2,36 +2,38 @@
 title: Dojo Version 4.0
 authorId: paul
 ---
- “Developer ergonomics improvements and automatic build time optimisations and code splitting”
 
 ## Being a Better Dojo
 
-We believe that developer ergonomics and strong community suport are fundamental reasons for choosing any framework. If you can't be comfortable and efficient working with a system why choose it in the first place? It's what leads us to engage with our community and constantly look ahead to a better, brighter Dojo.
+We believe that developer ergonomics and strong community support are fundamental reasons for choosing any framework. If you can't be comfortable and efficient working with a system why choose it in the first place? It's what leads us to engage with our community and constantly look ahead to a better, brighter Dojo.
 
-Two of the most considerable undertakings this release will allow the Dojo framework to focus on delivering a consistent and positive development experience. First, the underlying [Virtual DOM Engine](https://github.com/dojo/framework/issues/54) has been completely rewitten to allow vdom nodes and widgets to both be rendered as first-class citizens. This has opened up the opportunity to make a number of improvements like replacing the `ProjectorMixin` with an easier to use `renderer`. The `ProjectorMixin` was always one of the more confusing aspects that was immediately felt by new developers. We believe the `renderer` is more direct and consistent with how the vdom uses widgets throughout Dojo.
+Two of the most considerable undertakings this release will allow the Dojo framework to focus on delivering a consistent and positive development experience. First, the underlying [Virtual DOM Engine][vdom PR] has been completely rewritten to allow vdom nodes and widgets to both be rendered as first-class citizens.
 
-Next, we have consolidated and removed a number of modules in Dojo framework that have been kept around to provide tooling or legacy support. Modules like `List`, `DateObject`, `Task`, and `request` were tools brought over from the old Dojo Toolkit that had proved to be useful in the past. But, the more we've used Dojo with TypeScript and modern concepts, the less we find a need for these tools. So we made the decision to say goodbye to a lot of old, familiar friends to better focus on creating the best possible virtual DOM framework.
+ This has opened up the opportunity to make a number of improvements, like replacing the `ProjectorMixin` with an easier to use `renderer`. The `ProjectorMixin` was always one of the more confusing aspects that was immediately felt by new developers. We believe the `renderer` is more direct and consistent with how the vdom uses widgets throughout Dojo.
 
-been a complete rewrite of the underlying [Virtual DOM Engine](https://github.com/dojo/framework/issues/54) and a pruning of 
+Next, we have consolidated and removed a number of modules in the Dojo framework that have been kept around to provide tooling or legacy support. Modules like `List`, `DateObject`, `Task`, and `request` were tools brought over from the old Dojo Toolkit that had proved to be useful in the past. But, the more we've used Dojo with TypeScript and modern concepts, the less we find a need for these tools. So we made the decision to say goodbye to a lot of old, familiar friends to better focus on creating the best possible virtual DOM framework.
 
-* Goodbye ProjectorMixin
-* Consilidating dojo/framework
-    * A number of modules have been removed that provided legacy support to es5 browsers.
-    * Of note: dojo/core/request : use fetch polyfill; async interfaces Task; utilities and collections: List, DateObject, Observable
-* Outlets are now Widgets
-    * removed onEnter and onExit to make routes static. Will help w/ automatic code-splitting to improve performance and time-to-interaction
-* Updates to testing (unit, functional builds)
-* StoreProvider widget: https://github.com/dojo/framework/issues/76
-* @watch() for internal properties https://github.com/dojo/framework/issues/74
-* improved and added error & warning messages
+Dojo 4 adds dozens of other improvements that make it easier and more expressive. 
+
+* better ways of working with [`Outlet`s][Outlet PR]
+* a new [`StoreProvider` widget][StoreProvider PR] making store data easier to access in widgets
+* more descriptive error and warning messages
+
+You can read more about all of the new features in detail in the [Dojo 4 Migration Guide][Migration Guide].
 
 ## Migration
 
-* brief instructions `npm install @dojo/cli-upgrade-app --no-save` and run `dojo upgrade app`
-* Update cli commands and if you're using `@dojo/widgets` or `@dojo/interop` upgrade those to 4.0
-* See the [migration guide]() // TODO LINK
+The [`@dojo/cli-upgrade-app`][cli-upgrade] tool has been updated to allow for a smooth transition between Dojo 3 and Dojo 4. Simply upgrade Dojo's cli and widget packages to 4.0 and run `npm install @dojo/cli-upgrade-app@4 --no-save` and run `dojo upgrade app`. For more information please see the [migration guide][Migration Guide].
 
 ## Support
 
-* [Discord](https://discord.gg/M7yRngE)
-* Checkout our [roadmap](https://dojo.io/community/)
+Love what we're doing or having a problem? We ❤️ our community. Reach out to us on [Discord], check out our [roadmap] and see where Dojo is headed, and try out the new Dojo on [CodeSandbox]. Hope to see you soon!
+
+[vdom PR]: https://github.com/dojo/framework/issues/54
+[StoreProvider PR]: https://github.com/dojo/framework/issues/76
+[Outlet PR]: https://github.com/dojo/framework/pull/63
+[Migration Guide]:https://github.com/dojo/framework/blob/47dddefb4e237069b31cc45bc4216182fc2017b3/docs/V4-Migration-Guide.md
+[cli-upgrade]: https://www.npmjs.com/package/@dojo/cli-upgrade-app
+[Discord]: https://discord.gg/M7yRngE
+[roadmap]: https://dojo.io/community/
+[CodeSandbox]: https://codesandbox.io/s/github/dojo/dojo-codesandbox-template


### PR DESCRIPTION
Final draft of the Dojo 4 blog. The Migration Guide link will need to be updated after it's published.