### PR TITLE
Remove RawGit CDN

### DIFF
--- a/docviewer/src/common.ts
+++ b/docviewer/src/common.ts
@@ -485,7 +485,6 @@ export function slugify(str: string) {
 // raw.githubusercontent, and are not (as) rate limited.
 const sources = [
 	'https://rawcdn.githack.com/',
-	'https://cdn.rawgit.com/',
 	'https://gitcdn.xyz/repo/',
 	'https://raw.githubusercontent.com/'
 ];


### PR DESCRIPTION
RawGit is shutting down per this [tweet](https://twitter.com/rawgit/status/1049360165030567937?s=21).