### PR TITLE
Scope issues with functions used in Outlet's render property

### DIFF
--- a/site/source/tutorials/004_user_interactions/index.md
+++ b/site/source/tutorials/004_user_interactions/index.md
@@ -57,6 +57,10 @@ Now, run the app (using `dojo build -m dev -w memory -s`) and navigate to [local
 
 {% instruction 'Open the console window and click on any of the worker widgets to confirm that the `flip` method gets called as expected.' %}
 
+{% aside 'Automatic Binding of Handlers' %}
+The scope for event handlers and function properties are automatically bound to the `this` scope of the widget that defined the `v()` or `w()` call. If you are just passing on a property that has already been bound, then this will _not_ be bound again.
+{% endaside %}
+
 {% section %}
 
 ## Using event handlers

--- a/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/package.json
+++ b/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@dojo/framework": "^4.0.0",
+    "@dojo/widgets": "^4.0.0",
     "tslib": "~1.8.1"
   },
   "devDependencies": {

--- a/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/src/widgets/WorkerForm.ts
+++ b/site/source/tutorials/1010_containers_and_injecting_state/demo/finished/biz-e-corp/src/widgets/WorkerForm.ts
@@ -1,5 +1,4 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { TypedTargetEvent } from '@dojo/framework/widget-core/interfaces';
 import { v, w } from '@dojo/framework/widget-core/d';
 import { ThemedMixin, theme } from '@dojo/framework/widget-core/mixins/Themed';
 import Button from '@dojo/widgets/button';

--- a/site/source/tutorials/1020_registries/index.md
+++ b/site/source/tutorials/1020_registries/index.md
@@ -116,7 +116,7 @@ There are two ways to register a widget in a registry, the first is to define th
 
 {% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' line:3 %}
 
-{% task 'Add the registry item using the `@registry` decorator in `WorkerBack.ts`' %}
+{% task 'Add the registry item using the `@registry` decorator in `Worker.ts`' %}
 
 {% include_codefile 'demo/finished/biz-e-corp/src/widgets/Worker.ts' line:18 %}
 

--- a/site/source/tutorials/1030_routing/demo/finished/biz-e-corp/src/widgets/App.ts
+++ b/site/source/tutorials/1030_routing/demo/finished/biz-e-corp/src/widgets/App.ts
@@ -21,13 +21,13 @@ export default class App extends ThemedMixin(WidgetBase) {
 
 	private _workerData: WorkerProperties[] = workerData;
 
-	private _addWorker() {
+	private _addWorker = () => {
 		this._workerData = this._workerData.concat(this._newWorker);
 		this._newWorker = {};
 		this.invalidate();
 	}
 
-	private _onFormInput(data: Partial<WorkerFormData>) {
+	private _onFormInput = (data: Partial<WorkerFormData>) => {
 		this._newWorker = {
 			...this._newWorker,
 			...data

--- a/site/source/tutorials/1030_routing/index.md
+++ b/site/source/tutorials/1030_routing/index.md
@@ -102,6 +102,10 @@ The `renderer` function receives a `MatchDetails` object that provides informati
 
 Consider an `outlet` configured for a `path` of `about`, the widget that it returns from the `renderer` will render for a selected route `about` (described as an `index` match). The widget will also display for any route that the outlet's `path` partially matches, for example, `about/company` or `about/company/team`.
 
+{% aside 'Warning: Make sure functions passed used in render property are bound!' %}
+Functions passed to `v()` and `w()` in a render property need to already have been bound to the correct scope. This is because the render property is actually executed and returned from the `Outlet` and therefore in the auto binding system provided by dojo will be bound to the scope of the `Outlet`, and not your widget.
+{% endaside %}
+
 Simply returning the widget or nodes that need to be displayed when an outlet has matched is usually all that is required, however there are scenarios where it is necessary to explicitly define a widget for an `index` or `error` match. This is where `matchDetails` is beneficial. By using the information from `matchDetails`, we can create simple logic to determine which widget to render for each scenario.
 
 ```ts

--- a/site/source/tutorials/1030_routing/index.md
+++ b/site/source/tutorials/1030_routing/index.md
@@ -102,8 +102,8 @@ The `renderer` function receives a `MatchDetails` object that provides informati
 
 Consider an `outlet` configured for a `path` of `about`, the widget that it returns from the `renderer` will render for a selected route `about` (described as an `index` match). The widget will also display for any route that the outlet's `path` partially matches, for example, `about/company` or `about/company/team`.
 
-{% aside 'Warning: Make sure functions passed used in render property are bound!' %}
-Functions passed to `v()` and `w()` in a render property need to already have been bound to the correct scope. This is because the render property is actually executed and returned from the `Outlet` and therefore in the auto binding system provided by dojo will be bound to the scope of the `Outlet`, and not your widget.
+{% aside 'Warning: Make sure functions used in render property are bound!' %}
+Functions passed to `v()` and `w()` in a render property need to already have been bound to the correct scope. This is because the render property is actually executed and returned from the `Outlet` and therefore will be bound to the scope of the `Outlet` and not your widget.
 {% endaside %}
 
 Simply returning the widget or nodes that need to be displayed when an outlet has matched is usually all that is required, however there are scenarios where it is necessary to explicitly define a widget for an `index` or `error` match. This is where `matchDetails` is beneficial. By using the information from `matchDetails`, we can create simple logic to determine which widget to render for each scenario.

--- a/site/source/tutorials/1060_data_driven_widgets/demo/finished/biz-e-corp/src/widgets/App.ts
+++ b/site/source/tutorials/1060_data_driven_widgets/demo/finished/biz-e-corp/src/widgets/App.ts
@@ -21,13 +21,13 @@ export default class App extends ThemedMixin(WidgetBase) {
 
 	private _workerData: WorkerProperties[] = workerData;
 
-	private _addWorker() {
+	private _addWorker = () => {
 		this._workerData = this._workerData.concat(this._newWorker);
 		this._newWorker = {};
 		this.invalidate();
 	}
 
-	private _onFormInput(data: Partial<WorkerFormData>) {
+	private _onFormInput = (data: Partial<WorkerFormData>) => {
 		this._newWorker = {
 			...this._newWorker,
 			...data

--- a/site/source/tutorials/1060_data_driven_widgets/demo/initial/biz-e-corp/src/widgets/App.ts
+++ b/site/source/tutorials/1060_data_driven_widgets/demo/initial/biz-e-corp/src/widgets/App.ts
@@ -21,13 +21,13 @@ export default class App extends ThemedMixin(WidgetBase) {
 
 	private _workerData: WorkerProperties[] = workerData;
 
-	private _addWorker() {
+	private _addWorker = () => {
 		this._workerData = this._workerData.concat(this._newWorker);
 		this._newWorker = {};
 		this.invalidate();
 	}
 
-	private _onFormInput(data: Partial<WorkerFormData>) {
+	private _onFormInput = (data: Partial<WorkerFormData>) => {
 		this._newWorker = {
 			...this._newWorker,
 			...data


### PR DESCRIPTION
Update the tutorials to take into account that functions used in a render prop will not be bound correctly.

* Added an aside to tell users that functions are automatically bound.
* Added an aside that points out `Outlet`s as the exception to the binding

Also included a couple of other changes that we have open PRs.

Closes https://github.com/dojo/dojo.io/pull/464
Closes https://github.com/dojo/dojo.io/pull/463