### PR TITLE
Remove using 'memory' as the recommended method when watching

### DIFF
--- a/site/source/tutorials/001_static_content/index.md
+++ b/site/source/tutorials/001_static_content/index.md
@@ -30,11 +30,11 @@ You also need to be familiar with TypeScript as Dojo uses it extensively.
 
 Before we start making changes, let's start the application with the development server so that we can observe the impact of our changes. Run the following command in the application's root directory:
 
-`dojo build --mode dev --watch memory --serve`
+`dojo build --mode dev --watch --serve`
 
 or using the abbreviated parameters:
 
-`dojo build -m dev -w memory -s`
+`dojo build -m dev -w -s`
 
 Now, open up a web browser to [http://localhost:9999](http://localhost:9999) to view the current application.
 
@@ -50,7 +50,11 @@ To start customizing the application, let's remove the existing content. There a
 
 {% instruction 'Open `index.html` file in the `src` directory and remove the `<p>` tag and its content, "Welcome to biz-e-corp".' %}
 
-Notice that the page has automatically updated for us. That means that we can immediately see the impact of the change without having to stop our work and refresh or rebuild the application.
+Refresh the browser page to see the changes in your application.
+
+{% aside 'Webpack Dev Server' %}
+The build command also supports automatically refreshing the application when running in the memory watch mode. To enable this pass `memory` after the `--watch` option: `dojo build -m dev -w memory -s`.
+{% endaside %}
 
 Now, let's remove the "Hello, Dojo World!" message.
 

--- a/site/source/tutorials/003_creating_widgets/index.md
+++ b/site/source/tutorials/003_creating_widgets/index.md
@@ -110,7 +110,7 @@ With that change, the `App` widget is ready to serve as the root of our applicat
 {% instruction 'If you are working locally, run the following command:' %}
 
 ```bash
-dojo build -m dev -w memory -s
+dojo build -m dev -w -s
 ```
 
 then open up a web browser and navigate to [`http://localhost:9999`](http://localhost:9999). You should see the Biz-E-Bodies title that we started with, but if you examine the actual DOM, you will see that the Banner's `<h1>` tag has been wrapped by the App's `<div>`, so everything appears to be working.
@@ -185,7 +185,7 @@ export default class App extends WidgetBase {
 ```
 
 
-{% instruction 'Run the application with `dojo build -m dev -w memory -s` and navigate to [`http://localhost:9999`](http://localhost:9999).' %}
+{% instruction 'Run the application with `dojo build -m dev -w -s` and navigate to [`http://localhost:9999`](http://localhost:9999).' %}
 
 We have succeeded in rendering the widget, but there seem to be some styling issues. We'll come back to that in a bit. For now, let's continue refining the `Worker` widget to allow the application to configure it before it is rendered. In Dojo, this is done by creating an interface to pass configuration information into the widget.
 
@@ -238,7 +238,7 @@ protected render() {
 {% task 'Pass properties to the Worker widget to configure it.' %}
 
 {% aside 'Remember' %}
-You should already see the new values. However, if you shut down the build command, you can start it up again by running `dojo build -m dev -w memory -s` and navigating to `http://localhost:9999`.
+You should already see the new values. However, if you shut down the build command, you can start it up again by running `dojo build -m dev -w -s` and navigating to `http://localhost:9999`.
 {% endaside %}
 
 To use the functionality of the new `Worker` widget we will update the `render` method in the `App` class to pass in some properties. In a full Dojo application, these values could possibly be retrieved from an external state store or fetched from an external resource, but for now, we'll just use static properties. To learn more about working with stores in Dojo, take a look at the [dojo/stores](../comingsoon.html) tutorial in the advanced section.
@@ -281,7 +281,7 @@ To allow our `Worker` widget to be styled, we need to modify the class. First, a
 
 {% include_codefile 'demo/finished/biz-e-corp/src/styles/worker.m.css' lang:css %}
 
-`dojo build -m dev -w memory -s` will detect these new rules and generate the type declaration files automatically, allowing us to apply them to the `Worker` widget.
+`dojo build -m dev -w -s` will detect these new rules and generate the type declaration files automatically, allowing us to apply them to the `Worker` widget.
 
 {% instruction 'Return to `Worker.ts` and update the render method to add the classes:' %}
 

--- a/site/source/tutorials/004_user_interactions/index.md
+++ b/site/source/tutorials/004_user_interactions/index.md
@@ -53,7 +53,7 @@ flip(): void {
 }
 ```
 
-Now, run the app (using `dojo build -m dev -w memory -s`) and navigate to [localhost:9999](http://localhost:9999). Once there,
+Now, run the app (using `dojo build -m dev -w -s`) and navigate to [localhost:9999](http://localhost:9999). Once there,
 
 {% instruction 'Open the console window and click on any of the worker widgets to confirm that the `flip` method gets called as expected.' %}
 

--- a/site/source/tutorials/005_form_widgets/index.md
+++ b/site/source/tutorials/005_form_widgets/index.md
@@ -58,7 +58,7 @@ export default class WorkerForm extends ThemedMixin(WidgetBase)<WorkerFormProper
 ```
 
 {% aside 'Reminder' %}
-If you cannot see the application, remember to run `dojo build -m dev -w memory -s` to build the application and start the development server.
+If you cannot see the application, remember to run `dojo build -m dev -w -s` to build the application and start the development server.
 {% endaside %}
 
 This widget will render an empty form with a `submit` handler that prevents the form from being submitted to the server. Before we continue to expand on this starting point though, let's integrate the form into the application so we can observe the form as we add more features.

--- a/site/source/tutorials/006_deploying_to_production/index.md
+++ b/site/source/tutorials/006_deploying_to_production/index.md
@@ -29,7 +29,7 @@ You also need to be familiar with TypeScript as Dojo uses it extensively.
 
 {% task 'Create a production build.' %}
 
-Creating a production build of a Dojo application is straightforward. We have actually been creating an application for production throughout this tutorial series. If you have been following the tutorials locally, you have been using the `dojo build -m dev -w memory -s` command to build the application and start a web-server to view the application as it developed. This version of the application is almost the same as what should be deployed to production.
+Creating a production build of a Dojo application is straightforward. We have actually been creating an application for production throughout this tutorial series. If you have been following the tutorials locally, you have been using the `dojo build -m dev -w -s` command to build the application and start a web-server to view the application as it developed. This version of the application is almost the same as what should be deployed to production.
 
 {% instruction 'Run the `dojo build` command.' %}
 

--- a/site/source/tutorials/007_theming/index.md
+++ b/site/source/tutorials/007_theming/index.md
@@ -42,7 +42,7 @@ In order to theme our widgets, we must ensure that they each apply the `ThemedMi
 {% include_codefile 'demo/finished/biz-e-corp/src/widgets/Banner.ts' lines:1-14 highlight:3-7 title:'File: src/widgets/Banner.ts' lang:typescript %}
 
 {% aside 'Reminder' %}
-If you cannot see the application, remember to run `dojo build -m dev -w memory -s` to build the application and start the development server.
+If you cannot see the application, remember to run `dojo build -m dev -w -s` to build the application and start the development server.
 {% endaside %}
 
 This `Banner` widget will now have access to the classes in `banner.m.css` and can receive a `theme`. We use the `root` class to ensure that the theme we create can easily target the correct node.

--- a/site/source/tutorials/1060_data_driven_widgets/index.md
+++ b/site/source/tutorials/1060_data_driven_widgets/index.md
@@ -96,7 +96,7 @@ protected render() {
 }
 ```
 
-{% instruction 'Run the application with `dojo build -m dev -w memory -s` and navigate to [`http://localhost:9999`](http://localhost:9999).' %}
+{% instruction 'Run the application with `dojo build -m dev -w -s` and navigate to [`http://localhost:9999`](http://localhost:9999).' %}
 
 A solid foundation for a filterable list widget using a Dojo `TextInput` widget has been created and added to the existing `Banner`. Thus far, the widget is not connected to an external data source.
 


### PR DESCRIPTION
There are some issues using the memory watch mode that automatically refreshes the application the browser. So removing this mechanism as the defacto recommendation throughout the tutorials, added an aside that mentioned the support for the memory watch mode.